### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,17 +12,14 @@ jobs:
         fetch-depth: 0
 
     - name: Install latest stable rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
          toolchain: stable
          override: true
          components: rustfmt, clippy
 
     - name: Run cargo fmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check --verbose
 
     - name: cache rust
       uses: Swatinem/rust-cache@v2
@@ -52,7 +49,7 @@ jobs:
 
     - name: install dependencies
       shell: bash -l {0}
-      run: mamba install git compilers maturin pytest
+      run: mamba install git compilers maturin pytest crossenv libclang clangdev
 
     - name: build
       shell: bash -l {0}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,33 +11,23 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install latest stable rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-         toolchain: stable
-         override: true
-         components: rustfmt, clippy
-
-    - name: Run cargo fmt
-      run: cargo fmt --all -- --check --verbose
-
-    - name: cache rust
-      uses: Swatinem/rust-cache@v2
-
     - name: cache conda
       uses: actions/cache@v4
       env:
-        CACHE_NUMBER: 0
+        CACHE_NUMBER: 1
       with:
         path: ~/conda_pkgs_dir
         key:
           ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment.yml') }}
 
+    - name: cache rust
+      uses: Swatinem/rust-cache@v2
+
     - name: setup conda
-      uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
-        python-version: 3.11
+        python-version: 3.12
         channels: conda-forge,bioconda
         miniforge-variant: Mambaforge
         miniforge-version: latest
@@ -45,11 +35,24 @@ jobs:
         mamba-version: "*"
         activate-environment: sourmash_dev
         auto-activate-base: false
-        use-only-tar-bz2: true
+#        use-only-tar-bz2: true
+
+    - run: conda info
+    - run: conda list
+    - run: conda config --show
+
+    - run: mamba search rust
 
     - name: install dependencies
       shell: bash -l {0}
-      run: mamba install git compilers maturin pytest crossenv libclang clangdev
+      run: mamba install rust==1.75.0
+
+    - name: install dependencies 2
+      shell: bash -l {0}
+      run: mamba install compilers maturin pytest pandas
+
+    - name: Run cargo fmt
+      run: cargo fmt --all -- --check --verbose
 
     - name: build
       shell: bash -l {0}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,7 +12,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install latest stable rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@stable
       with:
          toolchain: stable
          override: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1754,7 +1754,6 @@ dependencies = [
  "niffler",
  "openssl",
  "pyo3",
- "pyo3-build-config",
  "rayon",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,6 @@ tokio = { version = "1.37.0", features = ["full"] }
 regex = "1.10.4"
 openssl = { version = "0.10", features = ["vendored"] }
 
-[build-dependencies]
-pyo3-build-config = { version = "0.21.2", features = ["resolve-config"] }
-
 [profile.release]
 #target-cpu=native
 lto = "thin"

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,0 @@
-use pyo3_build_config;
-
-fn main() {
-    // If you have an existing build.rs file, just add this line to it.
-    pyo3_build_config::use_pyo3_cfgs();
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ test = [
 
 [tool.maturin]
 python-source = "src/python"
-features = ["pyo3/extension-module"]
 
 [tool.maturin.target.x86_64-apple-darwin]
 macos-deployment-target = "10.14"


### PR DESCRIPTION
following https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/325

> Fix broken CI. Among other things,`actions-rs` is unmaintained per https://github.com/actions-rs/toolchain/issues/216. I think the original breakage might have been occasioned by the runner image for ubuntu-latest being updated about two weeks ago ([link](https://github.com/actions/runner-images/blob/ubuntu22/20240422.1/images/ubuntu/Ubuntu2204-Readme.md)).

A laundry list of problems to fix seems to have boiled down to:
* don't mix rustup installs with conda installs;
* if you're going to use conda-incubator/setup-miniconda, do not set `use-only-tar-bz2` to true (https://github.com/conda-incubator/setup-miniconda/issues/267#issuecomment-2102569634)