### PR TITLE
revert channel sizes

### DIFF
--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -626,9 +626,9 @@ pub async fn download_and_sketch(
     }
 
     // // create channels. buffer size can be changed - here it is 4 b/c we can do 3 downloads simultaneously
-    // // to do: see whether increasing buffer size speeds things up
-    let (send_sigs, recv_sigs) = tokio::sync::mpsc::channel::<Vec<Signature>>(1000);
-    let (send_failed, recv_failed) = tokio::sync::mpsc::channel::<FailedDownload>(100);
+    // // to do: see whether changing buffer size speeds things up
+    let (send_sigs, recv_sigs) = tokio::sync::mpsc::channel::<Vec<Signature>>(4);
+    let (send_failed, recv_failed) = tokio::sync::mpsc::channel::<FailedDownload>(4);
     // // Error channel for handling task errors
     let (error_sender, error_receiver) = tokio::sync::mpsc::channel::<anyhow::Error>(1);
 


### PR DESCRIPTION
This PR reverts the channel size, which I was starting to test while updating for 0.2.2 but didn't get around to benchmarking. 

I think -- channel size = the number of items collection prior to action, e.g. size 4 means 4 sigs are stored in the channel before they're written. So increasing channel size means you write larger batches at a single time. The more sigs we're storing at once, the more memory we'll require.

Seems like the timing is variable (perhaps depending on whatever else is happening on farm?), but not consistently faster for one or the other. Since smaller channel size will requires less memory, let's keep it small.

this branch, 9 accs:
```
        Command being timed: "sourmash scripts gbsketch update.20240503-fungi.head10.csv -o test10.zip --failed test10.failed.csv -r 1 --param-str dna,k=31,scaled=1000 --genomes-only"
        User time (seconds): 6.18
        System time (seconds): 0.38
        Percent of CPU this job got: 143%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:04.58
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 193512
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 77481
        Voluntary context switches: 5696
        Involuntary context switches: 27
        Swaps: 0
        File system inputs: 0
        File system outputs: 2096
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
v0.2.2 - 1, 9 accs

```
        Command being timed: "sourmash scripts gbsketch update.20240503-fungi.head10.csv -o test10.zip --failed test10.failed.csv -r 1 --param-str dna,k=31,scaled=1000 --genomes-only"
        User time (seconds): 6.23
        System time (seconds): 0.59
        Percent of CPU this job got: 86%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:07.87
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 185992
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 872
        Minor (reclaiming a frame) page faults: 72291
        Voluntary context switches: 8795
        Involuntary context switches: 22
        Swaps: 0
        File system inputs: 171632
        File system outputs: 2088
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

v0.2.2 - 2, 9 accs
```
...gbsketch is done! Sigs in 'test10.zip'. Fastas in '.'.
        Command being timed: "sourmash scripts gbsketch update.20240503-fungi.head10.csv -o test10.zip --failed test10.failed.csv -r 1 --param-str dna,k=31,scaled=1000 --genomes-only"
        User time (seconds): 6.13
        System time (seconds): 0.49
        Percent of CPU this job got: 134%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:04.92
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 178608
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 75617
        Voluntary context switches: 6852
        Involuntary context switches: 27
        Swaps: 0
        File system inputs: 0
        File system outputs: 2088
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```



this branch, 49 accs: 
```
Writing manifest
...gbsketch is done! Sigs in 'test50.zip'. Fastas in '.'.
        Command being timed: "sourmash scripts gbsketch update.20240503-fungi.head50.csv -o test50.zip --failed test50.failed.csv -r 1 --param-str dna,k=31,scaled=1000 --genomes-only"
        User time (seconds): 72.21
        System time (seconds): 3.20
        Percent of CPU this job got: 108%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:09.48
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1538424
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 594318
        Voluntary context switches: 57772
        Involuntary context switches: 100
        Swaps: 0
        File system inputs: 24
        File system outputs: 23400
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

v0.2.2, 49 accs
```
...gbsketch is done! Sigs in 'test50.zip'. Fastas in '.'.
        Command being timed: "sourmash scripts gbsketch update.20240503-fungi.head50.csv -o test50.zip --failed test50.failed.csv -r 1 --param-str dna,k=31,scaled=1000 --genomes-only"
        User time (seconds): 71.92
        System time (seconds): 2.95
        Percent of CPU this job got: 109%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 1:08.46
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1531164
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 137
        Minor (reclaiming a frame) page faults: 612880
        Voluntary context switches: 59575
        Involuntary context switches: 103
        Swaps: 0
        File system inputs: 19464
        File system outputs: 23392
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```