### PR TITLE
add rust version check and install link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ This plugin is an attempt to improve database generation by downloading assembli
 
 ## Installation
 
+Prior to install, verify that `rust` is installed:
+```
+rustc --version
+```
+> If not, follow [instruction for install here.](https://forge.rust-lang.org/infra/other-installation-methods.html)
+
+Install plugin:
 ```
 pip install sourmash_plugin_directsketch
 ```


### PR DESCRIPTION
fixes #32 

I was cleaning up my account a few days back and deleted cargo without thinking about it. I got this error and realized my mistake. After reinstalling rust everything is running again! 
I think you may want to add the link to install rust in your install instructions!

```
$ pip install sourmash_plugin_directsketch==0.3.0

Collecting sourmash_plugin_directsketch==0.3.0
  Using cached sourmash_plugin_directsketch-0.3.0.tar.gz (152 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.
      help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.

      Cargo, the Rust package manager, is not installed or is not on PATH.
      This package requires Rust and Cargo to compile extensions. Install it through
      the system's package manager or via https://rustup.rs/

      Checking for Rust toolchain....
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```