### PR TITLE
add `urlsketch` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@
 [![DOI](https://zenodo.org/badge/792101561.svg)](https://zenodo.org/doi/10.5281/zenodo.11165725)
 
 
-tl;dr - download and sketch NCBI Assembly Datasets by accession
+tl;dr - download and sketch data directly
 
 ## About
 
-This plugin is an attempt to improve database generation by downloading assemblies, checking md5sum, and sketching to a sourmash zipfile. FASTA files can also be saved if desired. It's quite fast, but still very much at alpha level. Here be dragons.
+Commands:
+
+- `gbsketch` - download and sketch NCBI Assembly Datasets by accession
+- `urlsketch` - download and sketch directly from a url
+
+This plugin is an attempt to improve sourmash database generation by downloading files, checking md5sum if provided or accessible, and sketching to a sourmash zipfile. FASTA files can also be saved if desired. It's quite fast, but still very much at alpha level. Here be dragons.
 
 ## Installation
 
@@ -16,7 +21,8 @@ This plugin is an attempt to improve database generation by downloading assembli
 pip install sourmash_plugin_directsketch
 ```
 
-## Usage
+## `gbsketch`
+download and sketch NCBI Assembly Datasets by accession
 
 ### Create an input file
 
@@ -43,15 +49,13 @@ For reference:
 
 To run the test accession file at `tests/test-data/acc.csv`, run:
 ```
-sourmash scripts gbsketch tests/test-data/acc.csv -o test.zip -f out_fastas -k --failed test.failed.csv -p dna,k=21,k=31,scaled=1000,abund -p protein,k=10,scaled=100,abund -r 1
+sourmash scripts gbsketch tests/test-data/acc.csv -o test-gbsketch.zip -f out_fastas -k --failed test.failed.csv -p dna,k=21,k=31,scaled=1000,abund -p protein,k=10,scaled=100,abund -r 1
 ```
 
 Full Usage:
 
 ```
-usage:  gbsketch [-h] [-q] [-d] -o OUTPUT [-f FASTAS] [-k] [--download-only] [--failed FAILED] [-p PARAM_STRING] [-c CORES]
-                 [-r RETRY_TIMES] [-g | -m]
-                 input_csv
+usage:  gbsketch [-h] [-q] [-d] [-o OUTPUT] [-f FASTAS] [-k] [--download-only] [--failed FAILED] [-p PARAM_STRING] [-c CORES] [-r RETRY_TIMES] [-g | -m] input_csv
 
 download and sketch GenBank assembly datasets
 
@@ -66,7 +70,7 @@ options:
                         output zip file for the signatures
   -f FASTAS, --fastas FASTAS
                         Write fastas here
-  -k, --keep-fastas     write FASTA files in addition to sketching. Default: do not write FASTA files
+  -k, --keep-fasta      write FASTA files in addition to sketching. Default: do not write FASTA files
   --download-only       just download genomes; do not sketch
   --failed FAILED       csv of failed accessions and download links (should be mostly protein).
   -p PARAM_STRING, --param-string PARAM_STRING
@@ -76,7 +80,61 @@ options:
   -r RETRY_TIMES, --retry-times RETRY_TIMES
                         number of times to retry failed downloads
   -g, --genomes-only    just download and sketch genome (DNA) files
-  -m, --proteomes-only  just download and sketch proteome (protein) files
+```
+
+## `urlsketch`
+download and sketch directly from a url
+### Create an input file
+
+First, create a file, e.g. `acc-url.csv` with identifiers, sketch names, and other required info.
+```
+accession,name,moltype,md5sum,download_filename,url
+GCA_000961135.2,GCA_000961135.2 Candidatus Aramenus sulfurataquae isolate AZ1-454,dna,47b9fb20c51f0552b87db5d44d5d4566,GCA_000961135.2_genomic.urlsketch.fna.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/961/135/GCA_000961135.2_ASM96113v2/GCA_000961135.2_ASM96113v2_genomic.fna.gz
+GCA_000961135.2,GCA_000961135.2 Candidatus Aramenus sulfurataquae isolate AZ1-454,protein,fb7920fb8f3cf5d6ab9b6b754a5976a4,GCA_000961135.2_protein.urlsketch.faa.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/961/135/GCA_000961135.2_ASM96113v2/GCA_000961135.2_ASM96113v2_protein.faa.gz
+GCA_000175535.1,GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14,dna,a1a8f1c6dc56999c73fe298871c963d1,GCA_000175535.1_genomic.urlsketch.fna.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_genomic.fna.gz
+```
+> Six columns must be present:
+> - `accession` - an accession or unique identifier. Ideally no spaces.
+> - `name` - full name for the sketch.
+> - `moltype` - is the file 'dna' or 'protein'?
+> - `md5sum` - expected md5sum (optional, will be checked after download if provided)
+> - `download_filename` - filename for FASTA download. Required if `--keep-fastas`, but useful for signatures, too (saved in sig data).
+> - `url` - direct link for the file
+
+### Run:
+
+To run the test accession file at `tests/test-data/acc-url.csv`, run:
+```
+sourmash scripts urlsketch tests/test-data/acc-url.csv -o test-urlsketch.zip -f out_fastas -k --failed test.failed.csv -p dna,k=21,k=31,scaled=1000,abund -p protein,k=10,scaled=100,abund -r 1
+```
+
+Full Usage:
+```
+usage:  urlsketch [-h] [-q] [-d] [-o OUTPUT] [-f FASTAS] [-k] [--download-only] [--failed FAILED] [-p PARAM_STRING] [-c CORES] [-r RETRY_TIMES] input_csv
+
+download and sketch GenBank assembly datasets
+
+positional arguments:
+  input_csv             a txt file or csv file containing accessions in the first column
+
+options:
+  -h, --help            show this help message and exit
+  -q, --quiet           suppress non-error output
+  -d, --debug           provide debugging output
+  -o OUTPUT, --output OUTPUT
+                        output zip file for the signatures
+  -f FASTAS, --fastas FASTAS
+                        Write fastas here
+  -k, --keep-fasta, --keep-fastq
+                        write FASTA/Q files in addition to sketching. Default: do not write FASTA files
+  --download-only       just download genomes; do not sketch
+  --failed FAILED       csv of failed accessions and download links (should be mostly protein).
+  -p PARAM_STRING, --param-string PARAM_STRING
+                        parameter string for sketching (default: k=31,scaled=1000)
+  -c CORES, --cores CORES
+                        number of cores to use (default is all available)
+  -r RETRY_TIMES, --retry-times RETRY_TIMES
+                        number of times to retry failed downloads
 ```
 
 ## Code of Conduct

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ build-backend = "maturin"
 
 [project.entry-points."sourmash.cli_script"]
 gbsketch = "sourmash_plugin_directsketch:Download_and_Sketch_Assemblies"
+urlsketch = "sourmash_plugin_directsketch:Download_and_Sketch_Url"
 
 [project.optional-dependencies]
 test = [

--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -403,7 +403,7 @@ async fn dl_sketch_url(
     let url = accinfo.url;
     let expected_md5 = accinfo.expected_md5sum;
     let download_filename = accinfo.download_filename;
-    let input_moltype = accinfo.input_moltype;
+    let moltype = accinfo.moltype;
 
     match download_with_retry(client, &url, expected_md5.as_deref(), retry_count)
         .await
@@ -419,7 +419,7 @@ async fn dl_sketch_url(
                 // let filename = download_filename.clone().unwrap();
                 let filename = "".to_string();
                 // sketch data
-                match input_moltype {
+                match moltype {
                     InputMolType::Dna => sigs.extend(
                         sketch_data(
                             name.clone(),
@@ -449,7 +449,7 @@ async fn dl_sketch_url(
             let failed_download = FailedDownload {
                 accession: accession.clone(),
                 name: name.clone(),
-                moltype: input_moltype.to_string(),
+                moltype: moltype.to_string(),
                 md5sum: expected_md5.map(|x| x.to_string()),
                 download_filename: download_filename,
                 url: Some(url),

--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -379,11 +379,11 @@ async fn dl_sketch_url(
     accinfo: AccessionData,
     location: &PathBuf,
     retry: Option<u32>,
-    keep_fastas: bool,
+    _keep_fastas: bool,
     dna_sigs: Vec<Signature>,
     prot_sigs: Vec<Signature>,
-    genomes_only: bool,
-    proteomes_only: bool,
+    _genomes_only: bool,
+    _proteomes_only: bool,
     download_only: bool,
 ) -> Result<(Vec<Signature>, Vec<FailedDownload>)> {
     let retry_count = retry.unwrap_or(3); // Default retry count
@@ -397,20 +397,15 @@ async fn dl_sketch_url(
     let download_filename = accinfo.download_filename;
     let input_moltype = accinfo.input_moltype;
 
-    match download_with_retry(
-        client,
-        &url,
-        expected_md5.as_ref().map(|x| x.as_str()),
-        retry_count,
-    )
-    .await
-    .ok()
+    match download_with_retry(client, &url, expected_md5.as_deref(), retry_count)
+        .await
+        .ok()
     {
         Some(data) => {
             // check keep_fastas instead??
             if let Some(download_filename) = download_filename {
-                let path = location.join(&download_filename);
-                fs::write(&path, &data).context("Failed to write data to file")?;
+                let path = location.join(download_filename);
+                fs::write(path, &data).context("Failed to write data to file")?;
             }
             if !download_only {
                 // let filename = download_filename.clone().unwrap();
@@ -722,12 +717,12 @@ pub async fn gbsketch(
 
     // Check if dna_sig_templates is empty and not keep_fastas
     if dna_sig_templates.is_empty() && !keep_fastas {
-        eprintln!("No DNA signature templates provided, and --keep-fastas is not set.");
+        eprintln!("No DNA signature templates provided, and --keep-fasta is not set.");
         proteomes_only = true;
     }
     // Check if protein_sig_templates is empty and not keep_fastas
     if prot_sig_templates.is_empty() && !keep_fastas {
-        eprintln!("No protein signature templates provided, and --keep-fastas is not set.");
+        eprintln!("No protein signature templates provided, and --keep-fasta is not set.");
         genomes_only = true;
     }
     if genomes_only {

--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -411,13 +411,12 @@ async fn dl_sketch_url(
     {
         Some(data) => {
             // check keep_fastas instead??
-            if let Some(download_filename) = download_filename {
+            if let Some(ref download_filename) = download_filename {
                 let path = location.join(download_filename);
                 fs::write(path, &data).context("Failed to write data to file")?;
             }
             if !download_only {
-                // let filename = download_filename.clone().unwrap();
-                let filename = "".to_string();
+                let filename = download_filename.clone().unwrap_or("".to_string());
                 // sketch data
                 match moltype {
                     InputMolType::Dna => sigs.extend(
@@ -451,7 +450,7 @@ async fn dl_sketch_url(
                 name: name.clone(),
                 moltype: moltype.to_string(),
                 md5sum: expected_md5.map(|x| x.to_string()),
-                download_filename: download_filename,
+                download_filename,
                 url: Some(url),
             };
             failed.push(failed_download);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ fn do_gbsketch(
     download_only: bool,
     output_sigs: Option<String>,
 ) -> anyhow::Result<u8> {
-    match directsketch::download_and_sketch(
+    match directsketch::gbsketch(
         py,
         input_csv,
         param_str,
@@ -83,9 +83,42 @@ fn do_gbsketch(
     }
 }
 
+#[pyfunction]
+#[allow(clippy::too_many_arguments)]
+fn do_urlsketch(
+    py: Python,
+    input_csv: String,
+    param_str: String,
+    failed_csv: String,
+    retry_times: u32,
+    fasta_location: String,
+    keep_fastas: bool,
+    download_only: bool,
+    output_sigs: Option<String>,
+) -> anyhow::Result<u8> {
+    match directsketch::urlsketch(
+        py,
+        input_csv,
+        param_str,
+        failed_csv,
+        retry_times,
+        fasta_location,
+        keep_fastas,
+        download_only,
+        output_sigs,
+    ) {
+        Ok(_) => Ok(0),
+        Err(e) => {
+            eprintln!("Error: {e}");
+            Ok(1)
+        }
+    }
+}
+
 #[pymodule]
 fn sourmash_plugin_directsketch(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(do_gbsketch, m)?)?;
+    m.add_function(wrap_pyfunction!(do_urlsketch, m)?)?;
     m.add_function(wrap_pyfunction!(set_tokio_thread_pool, m)?)?;
     Ok(())
 }

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -131,7 +131,7 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             args.param_string = ["k=31,scaled=1000"]
         notify(f"params: {args.param_string}")
 
-        if args.download_only and not args.keep_fastas:
+        if args.download_only and not args.keep_fasta:
             notify("Error: '--download-only' requires '--keep-fasta'.")
             sys.exit(-1)
         if args.output is None and not args.download_only:

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -78,7 +78,7 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
 
         num_threads = set_thread_pool(args.cores)
 
-        notify(f"downloading and sketching all accessions in '{args.input_csv} using {num_threads} threads")
+        notify(f"downloading and sketching all accessions in '{args.input_csv} using {args.retry_times} retries and {num_threads} threads")
 
         super().main(args)
         status = sourmash_plugin_directsketch.do_gbsketch(args.input_csv,

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -64,8 +64,8 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             args.param_string = ["k=31,scaled=1000"]
         notify(f"params: {args.param_string}")
 
-        if args.download_only and not args.keep_fastas:
-            notify("Error: '--download-only' requires '--keep-fastas'.")
+        if args.download_only and not args.keep_fasta:
+            notify("Error: '--download-only' requires '--keep-fasta'.")
             sys.exit(-1)
         if args.output is None and not args.download_only:
             notify("Error: output signature zipfile is required if not using '--download-only'.")
@@ -96,7 +96,7 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             notify("...gbsketch is done!")
             if args.output is not None:
                 notify(f"Sigs in '{args.output}'.")
-            if args.keep_fastas:
+            if args.keep_fasta:
                 notify(f"FASTAs in '{args.fastas}'.")
 
         return status

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -148,14 +148,12 @@ class Download_and_Sketch_Url(CommandLinePlugin):
         notify(f"downloading and sketching all accessions in '{args.input_csv} using {num_threads} threads")
 
         super().main(args)
-        status = sourmash_plugin_directsketch.do_gbsketch(args.input_csv,
+        status = sourmash_plugin_directsketch.do_urlsketch(args.input_csv,
                                                            args.param_string,
                                                            args.failed,
                                                            args.retry_times,
                                                            args.fastas,
                                                            args.keep_fasta,
-                                                           args.genomes_only,
-                                                           args.proteomes_only,
                                                            args.download_only,
                                                            args.output)
         
@@ -163,7 +161,7 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             notify("...gbsketch is done!")
             if args.output is not None:
                 notify(f"Sigs in '{args.output}'.")
-            if args.keep_fastas:
+            if args.keep_fasta:
                 notify(f"FASTAs in '{args.fastas}'.")
 
         return status

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,7 +89,7 @@ impl GenBankFileType {
 pub struct AccessionData {
     pub accession: String,
     pub name: String,
-    pub input_moltype: InputMolType,
+    pub moltype: InputMolType,
     pub url: reqwest::Url,
     pub expected_md5sum: Option<String>,
     pub download_filename: Option<String>, // need to require this if --keep-fastas are used
@@ -191,7 +191,7 @@ pub fn load_accession_info(
     let expected_header = vec![
         "accession",
         "name",
-        "input_moltype",
+        "moltype",
         "md5sum",
         "download_filename",
         "url",
@@ -222,11 +222,11 @@ pub fn load_accession_info(
             .get(1)
             .ok_or_else(|| anyhow!("Missing 'name' field"))?
             .to_string();
-        let input_moltype = record
+        let moltype = record
             .get(2)
-            .ok_or_else(|| anyhow!("Missing 'input_moltype' field"))?
+            .ok_or_else(|| anyhow!("Missing 'moltype' field"))?
             .parse::<InputMolType>()
-            .map_err(|_| anyhow!("Invalid 'input_moltype' value"))?;
+            .map_err(|_| anyhow!("Invalid 'moltype' value"))?;
         let expected_md5sum = record.get(3).map(|s| s.to_string());
         let mut download_filename = None;
         if keep_fasta {
@@ -259,7 +259,7 @@ pub fn load_accession_info(
         results.push(AccessionData {
             accession: acc,
             name,
-            input_moltype,
+            moltype,
             url,
             expected_md5sum,
             download_filename,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,15 @@ pub enum InputMolType {
     Protein,
 }
 
+impl InputMolType {
+    pub fn to_string(&self) -> String {
+        match self {
+            InputMolType::Dna => "dna".to_string(),
+            InputMolType::Protein => "protein".to_string(),
+        }
+    }
+}
+
 impl std::str::FromStr for InputMolType {
     type Err = ();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use reqwest::Url;
 use sourmash::cmd::ComputeParameters;
 use sourmash::signature::Signature;
+use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
 
@@ -11,11 +12,13 @@ pub enum InputMolType {
     Protein,
 }
 
-impl InputMolType {
-    pub fn to_string(&self) -> String {
+impl InputMolType {}
+
+impl fmt::Display for InputMolType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            InputMolType::Dna => "dna".to_string(),
-            InputMolType::Protein => "protein".to_string(),
+            InputMolType::Dna => write!(f, "dna"),
+            InputMolType::Protein => write!(f, "protein"),
         }
     }
 }
@@ -255,7 +258,7 @@ pub fn load_accession_info(
         // store accession data
         results.push(AccessionData {
             accession: acc,
-            name: name,
+            name,
             input_moltype,
             url,
             expected_md5sum,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -173,7 +173,6 @@ pub fn load_gbassembly_info(input_csv: String) -> Result<(Vec<GBAssemblyData>, u
     Ok((results, row_count))
 }
 
-#[allow(dead_code)]
 pub fn load_accession_info(
     input_csv: String,
     keep_fasta: bool,
@@ -228,14 +227,9 @@ pub fn load_accession_info(
             .parse::<InputMolType>()
             .map_err(|_| anyhow!("Invalid 'moltype' value"))?;
         let expected_md5sum = record.get(3).map(|s| s.to_string());
-        let mut download_filename = None;
-        if keep_fasta {
-            download_filename = Some(
-                record
-                    .get(4)
-                    .ok_or_else(|| anyhow!("Missing 'download_filename' field"))?
-                    .to_string(),
-            );
+        let download_filename = record.get(4).map(|s| s.to_string());
+        if keep_fasta && download_filename.is_none() {
+            return Err(anyhow!("Missing 'download_filename' field"));
         }
         let url = record
             .get(5)

--- a/tests/test-data/acc-url.csv
+++ b/tests/test-data/acc-url.csv
@@ -1,4 +1,4 @@
-accession,name,input_moltype,md5sum,download_filename,url
+accession,name,moltype,md5sum,download_filename,url
 GCA_000961135.2,GCA_000961135.2 Candidatus Aramenus sulfurataquae isolate AZ1-454,dna,47b9fb20c51f0552b87db5d44d5d4566,GCA_000961135.2_genomic.urlsketch.fna.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/961/135/GCA_000961135.2_ASM96113v2/GCA_000961135.2_ASM96113v2_genomic.fna.gz
 GCA_000961135.2,GCA_000961135.2 Candidatus Aramenus sulfurataquae isolate AZ1-454,protein,fb7920fb8f3cf5d6ab9b6b754a5976a4,GCA_000961135.2_protein.urlsketch.faa.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/961/135/GCA_000961135.2_ASM96113v2/GCA_000961135.2_ASM96113v2_protein.faa.gz
 GCA_000175535.1,GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14,dna,a1a8f1c6dc56999c73fe298871c963d1,GCA_000175535.1_genomic.urlsketch.fna.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_genomic.fna.gz

--- a/tests/test-data/acc-url.csv
+++ b/tests/test-data/acc-url.csv
@@ -1,4 +1,4 @@
 accession,name,input_moltype,md5sum,download_filename,url
-GCA_000961135.2,GCA_000961135.2 Candidatus Aramenus sulfurataquae isolate AZ1-454,dna,,GCA_000961135.2_genomic.urlsketch.fna.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/961/135/GCA_000961135.2_ASM96113v2/GCA_000961135.2_ASM96113v2_genomic.fna.gz
-GCA_000961135.2,GCA_000961135.2 Candidatus Aramenus sulfurataquae isolate AZ1-454,protein,,GCA_000961135.2_protein.urlsketch.faa.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/961/135/GCA_000961135.2_ASM96113v2/GCA_000961135.2_ASM96113v2_protein.faa.gz
-GCA_000175535.1,GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14,dna,,
+GCA_000961135.2,GCA_000961135.2 Candidatus Aramenus sulfurataquae isolate AZ1-454,dna,47b9fb20c51f0552b87db5d44d5d4566,GCA_000961135.2_genomic.urlsketch.fna.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/961/135/GCA_000961135.2_ASM96113v2/GCA_000961135.2_ASM96113v2_genomic.fna.gz
+GCA_000961135.2,GCA_000961135.2 Candidatus Aramenus sulfurataquae isolate AZ1-454,protein,fb7920fb8f3cf5d6ab9b6b754a5976a4,GCA_000961135.2_protein.urlsketch.faa.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/961/135/GCA_000961135.2_ASM96113v2/GCA_000961135.2_ASM96113v2_protein.faa.gz
+GCA_000175535.1,GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14,dna,a1a8f1c6dc56999c73fe298871c963d1,GCA_000175535.1_genomic.urlsketch.fna.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_genomic.fna.gz

--- a/tests/test-data/acc-url.csv
+++ b/tests/test-data/acc-url.csv
@@ -1,0 +1,4 @@
+accession,name,input_moltype,md5sum,download_filename,url
+GCA_000961135.2,GCA_000961135.2 Candidatus Aramenus sulfurataquae isolate AZ1-454,dna,,GCA_000961135.2_genomic.urlsketch.fna.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/961/135/GCA_000961135.2_ASM96113v2/GCA_000961135.2_ASM96113v2_genomic.fna.gz
+GCA_000961135.2,GCA_000961135.2 Candidatus Aramenus sulfurataquae isolate AZ1-454,protein,,GCA_000961135.2_protein.urlsketch.faa.gz,https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/961/135/GCA_000961135.2_ASM96113v2/GCA_000961135.2_ASM96113v2_protein.faa.gz
+GCA_000175535.1,GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14,dna,,

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -57,16 +57,16 @@ def test_gbsketch_simple(runtmp):
                 assert sig.md5sum() == ss3.md5sum()
     assert os.path.exists(failed)
     with open(failed, 'r') as failF:
-        header = next(failF).strip()
-        assert header == "accession,name,moltype,md5sum,download_filename,url"
-        for line in failF:
-            print(line)
-            acc, name, moltype, md5sum, download_filename, url = line.strip().split(',')
-            assert acc == "GCA_000175535.1"
-            assert name == "GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14"
-            assert moltype == "protein"
-            assert download_filename == "GCA_000175535.1_protein.faa.gz"
-            assert url == "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_protein.faa.gz"
+        fail_lines = failF.readlines()
+        print(fail_lines)
+        assert len(fail_lines) == 2
+        assert fail_lines[0] == "accession,name,moltype,md5sum,download_filename,url\n"
+        acc, name, moltype, md5sum, download_filename, url = fail_lines[1].strip().split(',')
+        assert acc == "GCA_000175535.1"
+        assert name == "GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14"
+        assert moltype == "protein"
+        assert download_filename == "GCA_000175535.1_protein.faa.gz"
+        assert url == "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_protein.faa.gz"
 
 
 def test_gbsketch_simple_url(runtmp):

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -177,7 +177,7 @@ def test_gbsketch_genomes_only_via_params(runtmp, capfd):
         elif 'GCA_000961135.2' in sig.name:
             assert sig.name == ss2.name
             assert sig.md5sum() == ss2.md5sum()
-    assert 'No protein signature templates provided, and --keep-fastas is not set.' in captured.err
+    assert 'No protein signature templates provided, and --keep-fasta is not set.' in captured.err
     assert 'Downloading and sketching genomes only.' in captured.err
 
 
@@ -206,7 +206,7 @@ def test_gbsketch_proteomes_only_via_params(runtmp, capfd):
     for sig in sigs:
         assert 'GCA_000961135.2' in sig.name
         assert sig.md5sum() == ss3.md5sum()
-    assert 'No DNA signature templates provided, and --keep-fastas is not set.' in captured.err
+    assert 'No DNA signature templates provided, and --keep-fasta is not set.' in captured.err
     assert 'Downloading and sketching proteomes only.' in captured.err
 
 
@@ -226,7 +226,7 @@ def test_gbsketch_save_fastas(runtmp):
     ss3 = sourmash.load_one_signature(sig3, ksize=30, select_moltype='protein')
 
     runtmp.sourmash('scripts', 'gbsketch', acc_csv, '-o', output,
-                    '--failed', failed, '-r', '1', '--fastas', out_dir, '--keep-fastas',
+                    '--failed', failed, '-r', '1', '--fastas', out_dir, '--keep-fasta',
                     '--param-str', "dna,k=31,scaled=1000", '-p', "protein,k=10,scaled=200")
 
     assert os.path.exists(output)
@@ -265,7 +265,7 @@ def test_gbsketch_download_only(runtmp, capfd):
     ss3 = sourmash.load_one_signature(sig3, ksize=30, select_moltype='protein')
 
     runtmp.sourmash('scripts', 'gbsketch', acc_csv, '--download-only',
-                    '--failed', failed, '-r', '1', '--fastas', out_dir, '--keep-fastas',
+                    '--failed', failed, '-r', '1', '--fastas', out_dir, '--keep-fasta',
                     '--param-str', "dna,k=31,scaled=1000", '-p', "protein,k=10,scaled=200")
 
     assert not runtmp.last_result.out # stdout should be empty

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -57,13 +57,16 @@ def test_gbsketch_simple(runtmp):
                 assert sig.md5sum() == ss3.md5sum()
     assert os.path.exists(failed)
     with open(failed, 'r') as failF:
-        next(failF)  # skip header line
+        header = next(failF).strip()
+        assert header == "accession,name,moltype,md5sum,download_filename,url"
         for line in failF:
-            acc, name, moltype, url = line.strip().split(',')
+            print(line)
+            acc, name, moltype, md5sum, download_filename, url = line.strip().split(',')
             assert acc == "GCA_000175535.1"
             assert name == "GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14"
             assert moltype == "protein"
-            assert url == '"https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_protein.faa.gz"'
+            assert download_filename == "GCA_000175535.1_protein.faa.gz"
+            assert url == "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_protein.faa.gz"
 
 
 def test_gbsketch_simple_url(runtmp):

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -55,3 +55,15 @@ def test_urlsketch_simple(runtmp):
                 assert sig.md5sum() == ss2.md5sum()
             else:
                 assert sig.md5sum() == ss3.md5sum()
+    assert os.path.exists(failed)
+    with open(failed, 'r') as failF:
+        header = next(failF).strip()
+        assert header == "accession,name,moltype,md5sum,download_filename,url"
+        for line in failF:
+            print(line)
+            acc, name, moltype, md5sum, download_filename, url = line.strip().split(',')
+            assert acc == "GCA_000175535.1"
+            assert name == "GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14"
+            assert moltype == "protein"
+            assert download_filename == "GCA_000175535.1_protein.faa.gz"
+            assert url == "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_protein.faa.gz"

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -132,3 +132,138 @@ def test_urlsketch_download_only(runtmp, capfd):
     assert set(fa_files) == set(['GCA_000175535.1_genomic.urlsketch.fna.gz', 'GCA_000961135.2_protein.urlsketch.faa.gz', 'GCA_000961135.2_genomic.urlsketch.fna.gz'])
     captured = capfd.readouterr()
     assert "Failed to send signatures: channel closed" not in captured.err
+
+
+def test_urlsketch_bad_acc(runtmp):
+    acc_csv = get_test_data('acc-url.csv')
+    acc_mod = runtmp.output('acc_mod.csv')
+    with open(acc_csv, 'r') as inF, open(acc_mod, 'w') as outF:
+        lines = inF.readlines()
+        for line in lines:
+            # if this acc exist in line, copy it and write an extra line with an invalid accession
+            outF.write(line)
+            print(line)
+            if "GCA_000175535.1" in line:
+                mod_line = line.replace('GCA_000175535.1', 'GCA_0001755559.1')  # add extra digit - should not be valid
+                print(mod_line)
+                outF.write(mod_line)
+
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+
+    sig1 = get_test_data('GCA_000175535.1.sig.gz')
+    sig2 = get_test_data('GCA_000961135.2.sig.gz')
+    sig3 = get_test_data('GCA_000961135.2.protein.sig.gz')
+    ss1 = sourmash.load_one_signature(sig1, ksize=31)
+    ss2 = sourmash.load_one_signature(sig2, ksize=31)
+    # why does this need ksize =30 and not ksize = 10!???
+    ss3 = sourmash.load_one_signature(sig3, ksize=30, select_moltype='protein')
+
+    runtmp.sourmash('scripts', 'urlsketch', acc_mod, '-o', output,
+                    '--failed', failed, '-r', '1',
+                    '--param-str', "dna,k=31,scaled=1000", '-p', "protein,k=10,scaled=200")
+
+    assert os.path.exists(output)
+    assert not runtmp.last_result.out # stdout should be empty
+
+    # Open the failed file
+    assert os.path.exists(failed)
+    with open(failed, 'r') as acc_file:
+        # Read the lines of the file
+        lines = acc_file.readlines()
+        # Check if the modified accession exists in the first column of any line
+        for line in lines:
+            print(line)
+            if "GCA_0001755559.1" in line.split(',')[0]:
+                assert True
+                break
+        else:
+            assert False, "Modified accession not found"
+
+    idx = sourmash.load_file_as_index(output)
+    sigs = list(idx.signatures())
+
+    assert len(sigs) == 3
+    for sig in sigs:
+        if 'GCA_000175535.1' in sig.name:
+            assert sig.name == ss1.name
+            assert sig.md5sum() == ss1.md5sum()
+        elif 'GCA_000961135.2' in sig.name:
+            assert sig.name == ss2.name
+            if sig.minhash.moltype == 'DNA':
+                assert sig.md5sum() == ss2.md5sum()
+            else:
+                assert sig.md5sum() == ss3.md5sum()
+
+def test_urlsketch_missing_accfile(runtmp, capfd):
+    acc_csv = runtmp.output('acc1.csv')
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'urlsketch', acc_csv, '-o', output,
+                    '--failed', failed, '-r', '1',
+                    '--param-str', "dna,k=31,scaled=1000", '-p', "protein,k=10,scaled=200")
+        
+    captured = capfd.readouterr()
+    print(captured.err)
+    assert "Error: No such file or directory" in captured.err
+
+
+def test_urlsketch_empty_accfile(runtmp, capfd):
+    acc_csv = get_test_data('acc1.csv')
+    with open(acc_csv, 'w') as file:
+        file.write('')
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'urlsketch', acc_csv, '-o', output,
+                    '--failed', failed, '-r', '1',
+                    '--param-str', "dna,k=31,scaled=1000", '-p', "protein,k=10,scaled=200")
+        
+    captured = capfd.readouterr()
+    print(captured.err)
+    assert 'Error: Invalid column names in CSV file. Columns should be: ["accession", "name", "moltype", "md5sum", "download_filename", "url"]' in captured.err
+
+
+def test_urlsketch_bad_acc_fail(runtmp, capfd):
+    acc_csv = get_test_data('acc-url.csv')
+    acc_mod = runtmp.output('acc_mod.csv')
+    with open(acc_csv, 'r') as inF, open(acc_mod, 'w') as outF:
+        lines = inF.readlines()
+        outF.write(lines[0])  # write the header line
+        for line in lines:
+            # if this acc exist in line, copy it and write
+            if "GCA_000175535.1" in line:
+                mod_line = line.replace('GCA_000175535.1', 'GCA_0001755559.1')  # add extra digit - should not be valid
+                print(mod_line)
+                outF.write(mod_line)
+    
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'urlsketch', acc_mod, '-o', output,
+                    '--failed', failed, '-r', '1',
+                    '--param-str', "dna,k=31,scaled=1000")
+        
+    captured = capfd.readouterr()
+    print(captured.out)
+    print(captured.err)
+    assert "Error: No signatures written, exiting." in captured.err
+
+
+
+def test_urlsketch_missing_output(runtmp):
+    # no output sig zipfile provided but also not --download-only
+    acc_csv = runtmp.output('acc1.csv')
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'urlsketch', acc_csv,
+                    '--failed', failed, '-r', '1',
+                    '--param-str', "dna,k=31,scaled=1000")
+
+    assert "Error: output signature zipfile is required if not using '--download-only'." in runtmp.last_result.err

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -314,8 +314,7 @@ def test_urlsketch_from_gbsketch_failed(runtmp, capfd):
             assert acc == "GCA_000175535.1"
             assert name == "GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14"
             assert moltype == "protein"
-            # TODO: fix download_filename
-            # assert download_filename == "GCA_000175535.1_protein.faa.gz"
+            assert download_filename == "GCA_000175535.1_protein.faa.gz"
             assert url == "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_protein.faa.gz"
 
 

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -67,3 +67,42 @@ def test_urlsketch_simple(runtmp):
             assert moltype == "protein"
             assert download_filename == "GCA_000175535.1_protein.faa.gz"
             assert url == "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_protein.faa.gz"
+
+def test_urlsketch_save_fastas(runtmp):
+    acc_csv = get_test_data('acc-url.csv')
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+    out_dir = runtmp.output('out_fastas')
+
+
+    sig1 = get_test_data('GCA_000175535.1.sig.gz')
+    sig2 = get_test_data('GCA_000961135.2.sig.gz')
+    sig3 = get_test_data('GCA_000961135.2.protein.sig.gz')
+    ss1 = sourmash.load_one_signature(sig1, ksize=31)
+    ss2 = sourmash.load_one_signature(sig2, ksize=31)
+    # why does this need ksize =30 and not ksize = 10!???
+    ss3 = sourmash.load_one_signature(sig3, ksize=30, select_moltype='protein')
+
+    runtmp.sourmash('scripts', 'urlsketch', acc_csv, '-o', output,
+                    '--failed', failed, '-r', '1', '--fastas', out_dir, '--keep-fasta',
+                    '--param-str', "dna,k=31,scaled=1000", '-p', "protein,k=10,scaled=200")
+
+    assert os.path.exists(output)
+    assert not runtmp.last_result.out # stdout should be empty
+    fa_files = os.listdir(out_dir)
+    assert set(fa_files) == set(['GCA_000175535.1_genomic.urlsketch.fna.gz', 'GCA_000961135.2_protein.urlsketch.faa.gz', 'GCA_000961135.2_genomic.urlsketch.fna.gz'])
+
+    idx = sourmash.load_file_as_index(output)
+    sigs = list(idx.signatures())
+
+    assert len(sigs) == 3
+    for sig in sigs:
+        if 'GCA_000175535.1' in sig.name:
+            assert sig.name == ss1.name
+            assert sig.md5sum() == ss1.md5sum()
+        elif 'GCA_000961135.2' in sig.name:
+            assert sig.name == ss2.name
+            if sig.minhash.moltype == 'DNA':
+                assert sig.md5sum() == ss2.md5sum()
+            else:
+                assert sig.md5sum() == ss3.md5sum()

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -106,3 +106,29 @@ def test_urlsketch_save_fastas(runtmp):
                 assert sig.md5sum() == ss2.md5sum()
             else:
                 assert sig.md5sum() == ss3.md5sum()
+
+
+def test_urlsketch_download_only(runtmp, capfd):
+    acc_csv = get_test_data('acc-url.csv')
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+    out_dir = runtmp.output('out_fastas')
+
+
+    sig1 = get_test_data('GCA_000175535.1.sig.gz')
+    sig2 = get_test_data('GCA_000961135.2.sig.gz')
+    sig3 = get_test_data('GCA_000961135.2.protein.sig.gz')
+    ss1 = sourmash.load_one_signature(sig1, ksize=31)
+    ss2 = sourmash.load_one_signature(sig2, ksize=31)
+    # why does this need ksize =30 and not ksize = 10!???
+    ss3 = sourmash.load_one_signature(sig3, ksize=30, select_moltype='protein')
+
+    runtmp.sourmash('scripts', 'urlsketch', acc_csv, '--download-only',
+                    '--failed', failed, '-r', '1', '--fastas', out_dir, '--keep-fasta',
+                    '--param-str', "dna,k=31,scaled=1000", '-p', "protein,k=10,scaled=200")
+
+    assert not runtmp.last_result.out # stdout should be empty
+    fa_files = os.listdir(out_dir)
+    assert set(fa_files) == set(['GCA_000175535.1_genomic.urlsketch.fna.gz', 'GCA_000961135.2_protein.urlsketch.faa.gz', 'GCA_000961135.2_genomic.urlsketch.fna.gz'])
+    captured = capfd.readouterr()
+    assert "Failed to send signatures: channel closed" not in captured.err

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -1,0 +1,57 @@
+"""
+Tests for urlsketch
+"""
+import os
+import pytest
+
+import sourmash
+import sourmash_tst_utils as utils
+from sourmash_tst_utils import SourmashCommandFailed
+
+
+
+def get_test_data(filename):
+    thisdir = os.path.dirname(__file__)
+    return os.path.join(thisdir, 'test-data', filename)
+
+def test_installed(runtmp):
+    with pytest.raises(utils.SourmashCommandFailed):
+        runtmp.sourmash('scripts', 'urlsketch')
+
+    assert 'usage:  urlsketch' in runtmp.last_result.err
+
+
+def test_urlsketch_simple(runtmp):
+    acc_csv = get_test_data('acc-url.csv')
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+
+    sig1 = get_test_data('GCA_000175535.1.sig.gz')
+    sig2 = get_test_data('GCA_000961135.2.sig.gz')
+    sig3 = get_test_data('GCA_000961135.2.protein.sig.gz')
+    ss1 = sourmash.load_one_signature(sig1, ksize=31)
+    ss2 = sourmash.load_one_signature(sig2, ksize=31)
+    # why does this need ksize =30 and not ksize = 10!???
+    ss3 = sourmash.load_one_signature(sig3, ksize=30, select_moltype='protein')
+
+    runtmp.sourmash('scripts', 'urlsketch', acc_csv, '-o', output,
+                    '--failed', failed, '-r', '1',
+                    '--param-str', "dna,k=31,scaled=1000", '-p', "protein,k=10,scaled=200")
+
+    assert os.path.exists(output)
+    assert not runtmp.last_result.out # stdout should be empty
+
+    idx = sourmash.load_file_as_index(output)
+    sigs = list(idx.signatures())
+
+    assert len(sigs) == 3
+    for sig in sigs:
+        if 'GCA_000175535.1' in sig.name:
+            assert sig.name == ss1.name
+            assert sig.md5sum() == ss1.md5sum()
+        elif 'GCA_000961135.2' in sig.name:
+            assert sig.name == ss2.name
+            if sig.minhash.moltype == 'DNA':
+                assert sig.md5sum() == ss2.md5sum()
+            else:
+                assert sig.md5sum() == ss3.md5sum()


### PR DESCRIPTION
`urlsketch` for downloading from any url, rather than just the genbank assembly datasets (`gbsketch`)

Notes:
- changes failure output format slightly! the new header is: `accession,name,moltype,md5sum,download_filename,url`, which matches the `urlsketch` input format.

- fixes #20
