### PR TITLE
more flexible decompression

### DIFF
--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -210,9 +210,13 @@ async fn sketch_data(
     moltype: String,
 ) -> Result<Vec<Signature>> {
     tokio::task::spawn_blocking(move || {
+
         let cursor = Cursor::new(compressed_data);
-        let mut fastx_reader =
-            parse_fastx_reader(cursor).context("Failed to parse FASTA/FASTQ data")?;
+        // use niffler to get decompressed reader
+        let (mut reader, compression) = niffler::get_reader(Box::new(cursor))?;
+        let mut fastx_reader = parse_fastx_reader(&mut reader).context("Failed to parse FASTA/FASTQ data")?;
+        // let mut fastx_reader =
+        //     parse_fastx_reader(cursor).context("Failed to parse FASTA/FASTQ data")?;
 
         let mut set_name = false;
         while let Some(record) = fastx_reader.next() {

--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -411,13 +411,12 @@ async fn dl_sketch_url(
     {
         Some(data) => {
             // check keep_fastas instead??
-            if let Some(download_filename) = download_filename {
+            if let Some(ref download_filename) = download_filename {
                 let path = location.join(download_filename);
                 fs::write(path, &data).context("Failed to write data to file")?;
             }
             if !download_only {
-                // let filename = download_filename.clone().unwrap();
-                let filename = "".to_string();
+                let filename = download_filename.clone().unwrap_or("".to_string());
                 // sketch data
                 match moltype {
                     InputMolType::Dna => sigs.extend(
@@ -451,7 +450,7 @@ async fn dl_sketch_url(
                 name: name.clone(),
                 moltype: moltype.to_string(),
                 md5sum: expected_md5.map(|x| x.to_string()),
-                download_filename: download_filename,
+                download_filename,
                 url: Some(url),
             };
             failed.push(failed_download);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -173,7 +173,6 @@ pub fn load_gbassembly_info(input_csv: String) -> Result<(Vec<GBAssemblyData>, u
     Ok((results, row_count))
 }
 
-#[allow(dead_code)]
 pub fn load_accession_info(
     input_csv: String,
     keep_fasta: bool,
@@ -228,14 +227,9 @@ pub fn load_accession_info(
             .parse::<InputMolType>()
             .map_err(|_| anyhow!("Invalid 'moltype' value"))?;
         let expected_md5sum = record.get(3).map(|s| s.to_string());
-        let mut download_filename = None;
-        if keep_fasta {
-            download_filename = Some(
-                record
-                    .get(4)
-                    .ok_or_else(|| anyhow!("Missing 'download_filename' field"))?
-                    .to_string(),
-            );
+        let download_filename = record.get(4).map(|s| s.to_string());
+        if keep_fasta && download_filename.is_none() {
+            return Err(anyhow!("Missing 'download_filename' field"));
         }
         let url = record
             .get(5)

--- a/tests/test-data/acc-url-xz.csv
+++ b/tests/test-data/acc-url-xz.csv
@@ -1,0 +1,2 @@
+accession,name,moltype,md5sum,download_filename,url
+achromobacter_xylosoxidans,achromobacter_xylosoxidans,dna,,achromobacter_xylosoxidans__01.asm.genomic.fna.tar.xz,https://ftp.ebi.ac.uk/pub/databases/AllTheBacteria/Releases/0.2/assembly/achromobacter_xylosoxidans__01.asm.tar.xz

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -314,8 +314,7 @@ def test_urlsketch_from_gbsketch_failed(runtmp, capfd):
             assert acc == "GCA_000175535.1"
             assert name == "GCA_000175535.1 Chlamydia muridarum MopnTet14 (agent of mouse pneumonitis) strain=MopnTet14"
             assert moltype == "protein"
-            # TODO: fix download_filename
-            # assert download_filename == "GCA_000175535.1_protein.faa.gz"
+            assert download_filename == "GCA_000175535.1_protein.faa.gz"
             assert url == "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_protein.faa.gz"
 
 

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -318,4 +318,26 @@ def test_urlsketch_from_gbsketch_failed(runtmp, capfd):
             assert url == "https://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/175/535/GCA_000175535.1_ASM17553v1/GCA_000175535.1_ASM17553v1_protein.faa.gz"
 
 
-# def test_urlsketch_from_urlsketch_failed(runtmp, capfd):
+def test_urlsketch_tarxz(runtmp):
+    acc_csv = get_test_data('acc-url-xz.csv')
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+
+    # sig3 = get_test_data('GCA_000961135.2.protein.sig.gz')
+    # ss1 = sourmash.load_one_signature(sig1, ksize=31)
+
+    runtmp.sourmash('scripts', 'urlsketch', acc_csv, '-o', output,
+                    '--failed', failed, '-r', '1',
+                    '--param-str', "dna,k=31,scaled=1000", '-p', "protein,k=10,scaled=200")
+
+    assert os.path.exists(output)
+    assert not runtmp.last_result.out # stdout should be empty
+
+    # idx = sourmash.load_file_as_index(output)
+    # sigs = list(idx.signatures())
+
+    # assert len(sigs) == 1
+    # for sig in sigs:
+    #     if 'GCA_000175535.1' in sig.name:
+    #         assert sig.name == ss1.name
+    #         assert sig.md5sum() == ss1.md5sum()


### PR DESCRIPTION
- aim to fix #40 by using niffler for decompression

current issue:
```
   error[E0277]: `dyn std::io::Read` cannot be sent between threads safely
         --> src/directsketch.rs:217:51
          |
      217 |         let mut fastx_reader = parse_fastx_reader(&mut reader).context("Failed to parse FASTA/FASTQ data")?;
          |                                ------------------ ^^^^^^^^^^^ `dyn std::io::Read` cannot be sent between threads safely
          |                                |
          |                                required by a bound introduced by this call
          |
          = help: the trait `Send` is not implemented for `dyn std::io::Read`, which is required by `&mut Box<dyn std::io::Read>: Send`
          = note: required for `Unique<dyn std::io::Read>` to implement `Send`
      note: required because it appears within the type `Box<dyn std::io::Read>`
         --> /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/alloc/src/boxed.rs:195:12
          = note: required because it appears within the type `&mut Box<dyn std::io::Read>`
      note: required by a bound in `parse_fastx_reader`
         --> /Users/ntward/.cargo/registry/src/index.crates.io-6f17d22bba15001f/needletail-0.5.1/src/parser/mod.rs:80:50
          |
      80  | pub fn parse_fastx_reader<'a, R: 'a + io::Read + Send>(
          |                                                  ^^^^ required by this bound in `parse_fastx_reader`
      
      For more information about this error, try `rustc --explain E0277`.
```