### PR TITLE
WIP: write sigs to tmpdir first to improve restart capacity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ fn do_gbsketch(
     proteomes_only: bool,
     download_only: bool,
     output_sigs: Option<String>,
+    tmpdir: Option<String>,
 ) -> anyhow::Result<u8> {
     match directsketch::gbsketch(
         py,
@@ -74,6 +75,7 @@ fn do_gbsketch(
         proteomes_only,
         download_only,
         output_sigs,
+        tmpdir,
     ) {
         Ok(_) => Ok(0),
         Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ fn set_tokio_thread_pool(num_threads: usize) -> PyResult<usize> {
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
+#[pyo3(signature = (input_csv, param_str, failed_csv, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, output_sigs=None, tmpdir=None))]
 fn do_gbsketch(
     py: Python,
     input_csv: String,
@@ -87,6 +88,7 @@ fn do_gbsketch(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
+#[pyo3(signature = (input_csv, param_str, failed_csv, retry_times, fasta_location, keep_fastas, download_only, output_sigs=None))]
 fn do_urlsketch(
     py: Python,
     input_csv: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ fn do_gbsketch(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (input_csv, param_str, failed_csv, retry_times, fasta_location, keep_fastas, download_only, output_sigs=None))]
+#[pyo3(signature = (input_csv, param_str, failed_csv, retry_times, fasta_location, keep_fastas, download_only, output_sigs=None, tmpdir=None))]
 fn do_urlsketch(
     py: Python,
     input_csv: String,
@@ -99,6 +99,7 @@ fn do_urlsketch(
     keep_fastas: bool,
     download_only: bool,
     output_sigs: Option<String>,
+    tmpdir: Option<String>,
 ) -> anyhow::Result<u8> {
     match directsketch::urlsketch(
         py,
@@ -110,6 +111,7 @@ fn do_urlsketch(
         keep_fastas,
         download_only,
         output_sigs,
+        tmpdir,
     ) {
         Ok(_) => Ok(0),
         Err(e) => {

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -43,6 +43,10 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
                        help='output zip file for the signatures')
         p.add_argument('-f', '--fastas',
                        help='Write fastas here', default = '.')
+        p.add_argument('--tmpdir',
+                       help='Write signatures to tmpdir first before adding to zipfile. \
+                            This allows gbsketch to recover after unexpected failures, rather than needing to \
+                            restart sketching from scratch.', default = None)
         p.add_argument('-k', '--keep-fasta', action='store_true',
                        help="write FASTA files in addition to sketching. Default: do not write FASTA files")
         p.add_argument('--download-only', help='just download genomes; do not sketch', action='store_true')
@@ -90,7 +94,8 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
                                                            args.genomes_only,
                                                            args.proteomes_only,
                                                            args.download_only,
-                                                           args.output)
+                                                           args.output,
+                                                           args.tmpdir)
         
         if status == 0:
             notify("...gbsketch is done!")

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -116,6 +116,10 @@ class Download_and_Sketch_Url(CommandLinePlugin):
         p.add_argument('input_csv', help="a txt file or csv file containing accessions in the first column")
         p.add_argument('-o', '--output', default=None,
                        help='output zip file for the signatures')
+        p.add_argument('--tmpdir',
+                       help='Write signatures to tmpdir first before adding to zipfile. \
+                            This allows urlsketch to recover after unexpected failures, rather than needing to \
+                            restart sketching from scratch.', default = None)
         p.add_argument('-f', '--fastas',
                        help='Write fastas here', default = '.')
         p.add_argument('-k', '--keep-fasta', '--keep-fastq', action='store_true',
@@ -160,7 +164,8 @@ class Download_and_Sketch_Url(CommandLinePlugin):
                                                            args.fastas,
                                                            args.keep_fasta,
                                                            args.download_only,
-                                                           args.output)
+                                                           args.output,
+                                                           args.tmpdir)
         
         if status == 0:
             notify("...gbsketch is done!")


### PR DESCRIPTION
To allow restart, write sigs to a tmpdir instead of directly to a zipfile. Then copy all sigs to the zipfile at the very end.

If we get interrupted, first read all the existing sigs that we can, build a manifest, and use this to intersect with sig templates to avoid rebuilding. I think the way to do this is to store a Hashmap of `filename: Records` for faster lookup+intersection as we loop through files.

To do:
- figure out how to properly do this intersection

thoughts:
- do we want to write mini manifests as we go, so we can just read those in upon restart? Currently set to read all files in the tmpdir.
- we currently have to build a new record for each signature b/c the filename + location needs to change. Is there a way to minimize this overhead / modify the existing record?
