### PR TITLE
MRG: fix ci by moving install from `mambaforge` --> `miniforge`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,6 @@ jobs:
         auto-update-conda: true
         python-version: 3.12
         channels: conda-forge,bioconda
-        miniforge-variant: Miniforge
         miniforge-version: latest
         use-mamba: true
         mamba-version: "*"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,7 @@ jobs:
         auto-update-conda: true
         python-version: 3.12
         channels: conda-forge,bioconda
-        miniforge-variant: Mambaforge
+        miniforge-variant: Miniforge
         miniforge-version: latest
         use-mamba: true
         mamba-version: "*"


### PR DESCRIPTION
`Mambaforge` is being sunset, all workflows should switch to `Miniforge`

https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/