### PR TITLE
MRG: batched zip reporting - notify after finishing batch to be clearer

### DIFF
--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -755,7 +755,6 @@ pub fn zipwriter_handle(
 
                 // if batch size is non-zero and is reached, close the current zip
                 if batch_size > 0 && acc_count >= batch_size {
-                    eprintln!("writing batch {}", batch_index);
                     if let Some(mut zip_writer) = zip_writer.take() {
                         if let Err(e) = zip_manifest
                             .async_write_manifest_to_zip(&mut zip_writer)
@@ -769,6 +768,7 @@ pub fn zipwriter_handle(
                             return;
                         }
                     }
+                    eprintln!("finished batch {}", batch_index);
                     // Start a new batch
                     batch_index += 1;
                     acc_count = 0;

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -112,7 +112,11 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
         if status == 0:
             notify("...gbsketch is done!")
             if args.output is not None:
-                notify(f"Sigs in '{args.output}'.")
+                if args.batch_size:
+                    batch_base = args.output.split('.zip')[0]
+                    notify(f"Sigs in '{batch_base}.1.zip', etc")
+                else:
+                    notify(f"Sigs in '{args.output}'.")
             if args.keep_fasta:
                 notify(f"FASTAs in '{args.fastas}'.")
 
@@ -193,7 +197,12 @@ class Download_and_Sketch_Url(CommandLinePlugin):
         if status == 0:
             notify("...gbsketch is done!")
             if args.output is not None:
-                notify(f"Sigs in '{args.output}'.")
+                if args.batch_size:
+                    batch_base = args.output.split('.zip')[0]
+                    notify(f"Sigs in '{batch_base}.1.zip', etc")
+                else:
+                    notify(f"Sigs in '{args.output}'.")
+
             if args.keep_fasta:
                 notify(f"FASTAs in '{args.fastas}'.")
 

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -693,6 +693,14 @@ def test_gbsketch_simple_batched_multiple(runtmp, capfd):
     captured = capfd.readouterr()
     print(captured.err)
 
+    assert "finished batch 1" in captured.err
+    assert "finished batch 2" in captured.err
+    print(captured.out)
+    print(runtmp.last_result.err)
+    batch_base = output.split('.zip')[0]
+    print(batch_base)
+    assert f"Sigs in '{batch_base}.1.zip', etc" in runtmp.last_result.err
+
     expected_siginfo = {
         (ss1.name, ss1.md5sum(), ss1.minhash.moltype),
         (ss2.name, ss2.md5sum(), ss2.minhash.moltype),

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -601,6 +601,14 @@ def test_urlsketch_simple_batched(runtmp, capfd):
     assert not os.path.exists(output) # for now, orig output file should be empty.
     captured = capfd.readouterr()
     print(captured.err)
+    assert "finished batch 1" in captured.err
+    assert "finished batch 2" in captured.err
+    assert "finished batch 3" in captured.err
+    print(captured.out)
+    print(runtmp.last_result.err)
+    batch_base = output.split('.zip')[0]
+    print(batch_base)
+    assert f"Sigs in '{batch_base}.1.zip', etc" in runtmp.last_result.err
 
     expected_siginfo = {
             (ss1.name, ss1.md5sum(), ss1.minhash.moltype),


### PR DESCRIPTION
Give output when we finish each batch, rather than when we start writing the manifest. Also improve the final location reporting for batched files.

- fixes #175 
