### PR TITLE
WIP: add delay before retrying

### DIFF
--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -248,6 +248,8 @@ async fn rest_api_download_with_retry(
         }
 
         attempts -= 1;
+        // delay by 1 second. NCBI allows 3 downloads/sec (10 with API KEY). This delay may help avoid issues.
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
     }
     Err(last_error.unwrap_or_else(|| {
         anyhow!(


### PR DESCRIPTION
NCBI allows 3 downloads/sec (10 with API KEY). Here I've added a 1 second delay before retrying. I think it may help avoid issues without increasing the total time too much.