### PR TITLE
MRG: `gbsketch` streaming processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,7 +2144,6 @@ dependencies = [
  "simple-error",
  "sourmash",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "zip",
 ]
@@ -2369,17 +2368,6 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
-dependencies = [
- "futures-core",
- "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2144,6 +2144,7 @@ dependencies = [
  "simple-error",
  "sourmash",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "zip",
 ]
@@ -2368,6 +2369,17 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ camino = "1.1.7"
 csv = "1.3.1"
 reqwest = { version = "0.12.15", features = ["json", "stream", "blocking"] }
 tokio = { version = "1.44.1", features = ["full"] }
-tokio-util = "0.7.14"
+tokio-util = {version = "0.7.14", features = ["io", "io-util"]}
+tokio-stream = "0.1.17"
 regex = "1.11.1"
 chrono = "0.4.32"
 lazy_static = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ csv = "1.3.1"
 reqwest = { version = "0.12.15", features = ["json", "stream", "blocking"] }
 tokio = { version = "1.44.1", features = ["full"] }
 tokio-util = {version = "0.7.14", features = ["io", "io-util"]}
-tokio-stream = "0.1.17"
 regex = "1.11.1"
 chrono = "0.4.32"
 lazy_static = "1.5.0"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ To build a single database after batched sketching, you can use `sig cat` to bui
 
 ### Memory Requirements
 
-Directsketch downloads the full file(s), checks the `md5sum` if provided, then sketches the data (for `gbsketch`, we instead check the `crc32` checksums contained in gzipped FASTA files). **You will need enough memory to hold files associated with `n` accessions in memory at once**, where `n` is the number of simultaneous downloads (`--n-simultaneous-downloads`; default 10). For microbial and viral genomes, this is trivial. For large eukaryotic genomes (e.g. plants!), be sure to provide sufficient memory or decrease `n`. You can tune the number of simultaneous downloads (and thus, the number of genomes/proteomes that will be in memory simultaneously) with `--n-simultaneous-downloads`.
+`gbsketch` streams the downloaded data, sketching/writing as it goes. It does not check an `md5sum`, but does check the internal `crc32` checksums available in the gzipped FASTA files to make sure we obtained the full download. For now, `urlsketch` downloads the full file(s), checks the `md5sum` if provided, then sketches the data.
+
+**For `urlsketch` only, you will need enough memory to hold files associated with `n` accessions in memory at once**, where `n` is the number of simultaneous downloads (`--n-simultaneous-downloads`; default 10). For microbial and viral genomes, this is trivial. For large eukaryotic genomes (e.g. plants!), be sure to provide sufficient memory or decrease `n`. You can tune the number of simultaneous downloads (and thus, the number of genomes/proteomes that will be in memory simultaneously) with `--n-simultaneous-downloads`.
 
 ### Rerunning failures
 
@@ -95,7 +97,8 @@ summary of sketches:
 Full Usage:
 
 ```
-usage:  gbsketch [-h] [-q] [-d] [-o OUTPUT] [-f FASTAS] [--batch-size BATCH_SIZE] [-k] [--download-only] [--failed FAILED] [--checksum-fail CHECKSUM_FAIL] [-p PARAM_STRING] [-c CORES] [-r RETRY_TIMES] [-n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30}] [-a API_KEY] [-g | -m]
+usage:  gbsketch [-h] [-q] [-d] [-o OUTPUT] [-f FASTAS] [--batch-size BATCH_SIZE] [-k] [--download-only] [--failed FAILED] [--checksum-fail CHECKSUM_FAIL] [-p PARAM_STRING] [-c CORES] [-r RETRY_TIMES]
+                 [-n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30}] [-a API_KEY] [-v] [--write-urlsketch-csv] [-g | -m]
                  input_csv
 
 download and sketch GenBank assembly datasets
@@ -112,7 +115,8 @@ options:
   -f FASTAS, --fastas FASTAS
                         Write fastas here
   --batch-size BATCH_SIZE
-                        Write smaller zipfiles, each containing sigs associated with this number of accessions. This allows gbsketch to recover after unexpected failures, rather than needing to restart sketching from scratch. Default: write all sigs to single zipfile.
+                        Write smaller zipfiles, each containing sigs associated with this number of accessions. This allows gbsketch to recover after unexpected failures, rather than needing to restart
+                        sketching from scratch. Default: write all sigs to single zipfile.
   -k, --keep-fasta      Write FASTA files. Default: do not write FASTA files.
   --download-only       Download FASTAS but do not sketch. Requires '--keep-fasta'. By default this downloads both genomes and proteomes.
   --failed FAILED       CSV of failed accessions and download links (should be mostly protein).
@@ -128,9 +132,11 @@ options:
                         Number of files to download simultaneously (1-30; default=10). Note that simultaneous downloads are held in memory during download. Please limit downloads accordingly for large genomes.
   -a API_KEY, --api-key API_KEY
                         API Key for NCBI REST API. Alternatively, set NCBI_API_KEY environmental variable. If provided, will be used when downloading the initial dehyrated file.
+  -v, --verbose         print progress for every download.
+  --write-urlsketch-csv
+                        Write urlsketch-formatted csv with all direct download links. Will be '{input_csv}.urlsketch.csv'.
   -g, --genomes-only    Download and sketch genome (DNA) files only.
   -m, --proteomes-only  Download and sketch proteome (protein) files only.
-  -v, --verbose         print progress for every download.
 ```
 
 ## `urlsketch`

--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -240,6 +240,9 @@ pub async fn stream_and_process_with_retry(
             let mut stream = response.bytes_stream();
 
             while let Some(chunk) = stream.next().await {
+                if let Err(e) = pyo3::Python::with_gil(|py| py.check_signals()) {
+                    return Err(anyhow::anyhow!("Caught Python interrupt: {}", e));
+                }
                 match chunk {
                     Ok(bytes) => {
                         if let Err(e) = writer.write_all(&bytes).await {
@@ -1387,7 +1390,7 @@ pub async fn gbsketch(
             eprintln!("Failed to write urlsketch csv with download links: {:#}", e);
         } else {
             eprintln!(
-                "Wrote urlsketch csv with download links to {}",
+                "Wrote urlsketch csv with download links to '{}'",
                 urlsketch_path
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ fn set_tokio_thread_pool(num_threads: usize) -> PyResult<usize> {
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (input_csv, param_str, failed_csv, failed_checksums, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, api_key, verbose, output_sigs=None))]
+#[pyo3(signature = (input_csv, param_str, failed_csv, failed_checksums, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, api_key, verbose, write_urlsketch_csv, output_sigs=None))]
 fn do_gbsketch(
     py: Python,
     input_csv: String,
@@ -66,6 +66,7 @@ fn do_gbsketch(
     n_permits: usize,
     api_key: String,
     verbose: bool,
+    write_urlsketch_csv: bool,
     output_sigs: Option<String>,
 ) -> anyhow::Result<u8> {
     match directsketch::gbsketch(
@@ -84,6 +85,7 @@ fn do_gbsketch(
         n_permits,
         api_key,
         verbose,
+        write_urlsketch_csv,
         output_sigs,
     ) {
         Ok(_) => Ok(0),

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -128,6 +128,17 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             default=None,
             help="API Key for NCBI REST API. Alternatively, set NCBI_API_KEY environmental variable. If provided, will be used when downloading the initial dehyrated file.",
         )
+        p.add_argument(
+            "-v",
+            "--verbose",
+            action="store_true",
+            help="print progress for every download.",
+        )
+        p.add_argument(
+            "--write-urlsketch-csv",
+            action="store_true",
+            help="Write urlsketch-formatted csv with all direct download links. Will be '{input_csv}.urlsketch.csv'.",
+        )
         group = p.add_mutually_exclusive_group()
         group.add_argument(
             "-g",
@@ -140,12 +151,6 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             "--proteomes-only",
             action="store_true",
             help="Download and sketch proteome (protein) files only.",
-        )
-        group.add_argument(
-            "-v",
-            "--verbose",
-            action="store_true",
-            help="print progress for every download.",
         )
 
     def main(self, args):
@@ -207,6 +212,7 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             args.n_simultaneous_downloads,
             args.api_key,
             args.verbose,
+            args.write_urlsketch_csv,
             args.output,
         )
 

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -316,6 +316,12 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             action="store_true",
             help="Skip input rows with empty or improper URLs. Warning: these will NOT be added to the failures file.",
         )
+        p.add_argument(
+            "-v",
+            "--verbose",
+            action="store_true",
+            help="print progress for every download.",
+        )
         group = p.add_mutually_exclusive_group()
         group.add_argument(
             "-g",
@@ -328,12 +334,6 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             "--proteomes-only",
             action="store_true",
             help="Download and sketch proteome (protein) files only.",
-        )
-        group.add_argument(
-            "-v",
-            "--verbose",
-            action="store_true",
-            help="print progress for every download.",
         )
 
     def main(self, args):

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,7 +3,6 @@ use reqwest::Url;
 use sourmash::collection::Collection;
 use std::collections::HashMap;
 use std::fmt;
-use tokio::io::AsyncWriteExt;
 
 pub mod buildutils;
 use crate::utils::buildutils::{BuildManifest, BuildRecord};
@@ -114,7 +113,7 @@ impl ToCsvRow for AccessionData {
             "{},{},{},{},{},{},{}\n",
             self.accession,
             self.name,
-            self.moltype.to_string(),
+            self.moltype,
             md5sum,
             self.download_filename.clone().unwrap_or_default(),
             url,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -46,8 +46,6 @@ impl std::str::FromStr for InputMolType {
 pub enum GenBankFileType {
     Genomic,
     Protein,
-    AssemblyReport,
-    Checksum,
 }
 
 impl GenBankFileType {
@@ -55,35 +53,12 @@ impl GenBankFileType {
         match self {
             GenBankFileType::Genomic => "_genomic.fna.gz",
             GenBankFileType::Protein => "_protein.faa.gz",
-            GenBankFileType::AssemblyReport => "_assembly_report.txt",
-            GenBankFileType::Checksum => "md5checksums.txt",
         }
-    }
-
-    //use for checksums
-    #[allow(dead_code)]
-    pub fn server_filename(&self, full_name: &str) -> String {
-        format!("{}{}", full_name, self.suffix())
     }
 
     #[allow(dead_code)]
     pub fn filename_to_write(&self, accession: &str) -> String {
-        match self {
-            GenBankFileType::Checksum => format!("{}_{}", accession, self.suffix()),
-            _ => format!("{}{}", accession, self.suffix()),
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn url(&self, base_url: &Url, full_name: &str) -> Url {
-        match self {
-            GenBankFileType::Checksum => base_url
-                .join(&format!("{}/{}", full_name, self.suffix()))
-                .unwrap(),
-            _ => base_url
-                .join(&format!("{}/{}{}", full_name, full_name, self.suffix()))
-                .unwrap(),
-        }
+        format!("{}{}", accession, self.suffix())
     }
 
     #[allow(dead_code)]
@@ -91,7 +66,6 @@ impl GenBankFileType {
         match self {
             GenBankFileType::Genomic => "DNA".to_string(),
             GenBankFileType::Protein => "protein".to_string(),
-            _ => "".to_string(),
         }
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -47,36 +47,6 @@ impl std::str::FromStr for InputMolType {
     }
 }
 
-#[allow(dead_code)]
-#[derive(PartialEq, Clone)]
-pub enum GenBankFileType {
-    Genomic,
-    Protein,
-}
-
-impl GenBankFileType {
-    pub fn suffix(&self) -> &'static str {
-        match self {
-            GenBankFileType::Genomic => "_genomic.fna.gz",
-            GenBankFileType::Protein => "_protein.faa.gz",
-        }
-    }
-
-    #[allow(dead_code)]
-    pub fn filename_to_write(&self, accession: &str) -> String {
-        format!("{}{}", accession, self.suffix())
-    }
-
-    #[allow(dead_code)]
-    pub fn moltype(&self) -> String {
-        match self {
-            GenBankFileType::Genomic => "DNA".to_string(),
-            GenBankFileType::Protein => "protein".to_string(),
-        }
-    }
-}
-
-#[allow(dead_code)]
 #[derive(Clone, Debug)]
 pub struct AccessionData {
     pub accession: String,
@@ -119,12 +89,6 @@ impl UrlInfo {
     pub fn new(url: reqwest::Url, md5sum: Option<String>, range: Option<(usize, usize)>) -> Self {
         UrlInfo { url, md5sum, range }
     }
-}
-
-#[derive(Clone)]
-pub struct GBAssemblyData {
-    pub accession: String,
-    pub name: String,
 }
 
 pub fn load_gbsketch_info(
@@ -507,31 +471,7 @@ pub struct FailedDownload {
     range: String,
 }
 
-#[allow(dead_code)]
 impl FailedDownload {
-    /// Build a `FailedDownload` from `GBAssemblyData` with detailed information
-    pub fn from_gbassembly(
-        accession: String,
-        name: String,
-        moltype: String,
-        md5sum: Option<String>,            // Single MD5 checksum
-        download_filename: Option<String>, // Download filename
-        url: Option<reqwest::Url>,         // URL for the file
-        range: Option<(usize, usize)>,     // Optional range for the download
-    ) -> Self {
-        Self {
-            accession,
-            name,
-            moltype,
-            md5sum: md5sum.unwrap_or_default(),
-            download_filename: download_filename.unwrap_or_default(),
-            url: url.map(|u| u.to_string()).unwrap_or_default(),
-            range: range
-                .map(|(start, end)| format!("{}-{}", start, end))
-                .unwrap_or_default(), // Format range or use ""
-        }
-    }
-
     fn parse_to_separated_string<T, F>(url_info: &[UrlInfo], mut extractor: F) -> String
     where
         F: FnMut(&UrlInfo) -> Option<T>,

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -1290,7 +1290,7 @@ def test_gbsketch_from_gbsketch_failed(runtmp, capfd):
     captured = capfd.readouterr()
     print(captured.out)
     print(captured.err)
-    assert "Last error: Parsed ZIP archive successfully, but no download links were found. Are your accessions valid?" in captured.err
+    assert "Are your accessions valid?" in captured.err
 
 
 def test_gbsketch_write_urlsketch_csv(runtmp, capfd):

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -1250,9 +1250,9 @@ def test_gbsketch_verbose(runtmp, capfd):
     print(captured.out)
     print(captured.err)
 
-    assert "Starting accession 1/2 (50%) - moltype: DNA" in captured.out
-    assert "Starting accession 1/2 (50%) - moltype: protein" in captured.out
-    assert "Starting accession 2/2 (100%) - moltype: DNA" in captured.out
+    assert "Starting download 1/3 (33%) - accession: 'GCA_000961135.2', moltype: DNA" in captured.out
+    assert "Starting download 2/3 (67%) - accession: 'GCA_000961135.2', moltype: protein" in captured.out
+    assert "Starting download 3/3 (100%) - accession: 'GCA_000175535.1', moltype: DNA" in captured.out
 
 
 def test_gbsketch_from_gbsketch_failed(runtmp, capfd):


### PR DESCRIPTION
This PR enables processing directly on the stream (`gbsketch` only here), meaning we do not have to download the entire file prior to processing! This should reduce memory requirements, since we no longer need to hold full genomes in memory. 

Other internal changes:
- We now read gbsketch input directly to an `AccessionData` struct, rather than having a separate bespoke struct for `gbsketch`. We also use `AccessionData` directly instead of building a `FailedDownload`. These changes simplify processing and will better enable code reuse between `gbsketch` and `urlsketch`.
- After finding the fetch urls via the dehydrated file, we then add them to the `AccessionData` structs and use `stream_and_process_with_retry` to stream and save/sketch the data. This function should be reusable for `urlsketch`, if we can add md5sum checks. Not really sure how useful having that field is for `urlsketch` anyway, since folks need to go find the md5sum for their files.
- added csv writing trait, which allowed for consolidation of csv writing handles
- enabled option to write `urlsketch` file from gbsketch, meaning we can skip finding the links a second time. This will probably be more useful after I get `urlsketch` updated with streaming methods to prevent memory issues.
- use `.incomplete` for incomplete fastas, rename once finished. Current approach deletes the incomplete fastas when we're going to retry or if fastx parsing failed, but not if `Ctrl-C` is encountered. Happy to modify if folks want that behavior to change. We truncate a file on opening, so there's no risk of appending to existing *incomplete files on subsequence runs.

Fixes:
- #228 
- #165 
- #47