### PR TITLE
MRG: optionally avoid re-downloading existing FASTA when using `--keep-fasta`

### DIFF
--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -1400,14 +1400,14 @@ pub async fn urlsketch(
     }
 
     // Open the file containing the accessions synchronously
-    let (accession_info, n_accs) = load_accession_info(input_csv, keep_fastas, force)?;
+    let (mut accession_info, n_accs) = load_accession_info(input_csv, keep_fastas, force)?;
     if n_accs == 0 {
         bail!("No accessions to download and sketch.")
     }
 
     // filter any accessions that aren't needed (already sketched/downloaded)
     if filter {
-        let (accession_info, skipped_empty_url, skipped_unneeded) = filter_accessions_to_download(
+        let (filtered, _, skipped_unneeded) = filter_accessions_to_download(
             accession_info,
             &existing_records_map,
             &sig_templates,
@@ -1415,6 +1415,8 @@ pub async fn urlsketch(
             keep_fastas,
             filter,
         )?;
+
+        accession_info = filtered;
 
         let skipped_unneeded = skipped_unneeded.load(Ordering::Relaxed);
         if skipped_unneeded > 0 {

--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -1091,8 +1091,13 @@ pub async fn process_accession_stream(
 
 async fn prepare_signature_output(
     output_sigs: &Option<String>,
+    batch_size: usize,
 ) -> Result<(HashMap<String, BuildManifest>, usize, bool), anyhow::Error> {
     if let Some(ref output_sigs) = output_sigs {
+        if batch_size == 0 {
+            // No batching, so no need to check existing output
+            return Ok((HashMap::new(), 1, false));
+        }
         let outpath = Utf8PathBuf::from(output_sigs);
         if outpath.extension().map_or(true, |ext| ext != "zip") {
             bail!("Output must be a zip file.");
@@ -1177,7 +1182,7 @@ pub async fn gbsketch(
 ) -> Result<(), anyhow::Error> {
     let batch_size = batch_size as usize;
     let (existing_records_map, batch_index, filter) =
-        prepare_signature_output(&output_sigs).await?;
+        prepare_signature_output(&output_sigs, batch_size).await?;
 
     // set up fasta download path
     let download_path = Utf8PathBuf::from(&fasta_location);
@@ -1380,7 +1385,7 @@ pub async fn urlsketch(
 ) -> Result<(), anyhow::Error> {
     let batch_size = batch_size as usize;
     let (existing_records_map, batch_index, filter) =
-        prepare_signature_output(&output_sigs).await?;
+        prepare_signature_output(&output_sigs, batch_size).await?;
 
     // set up fasta download path
     let download_path = Utf8PathBuf::from(&fasta_location);

--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -918,7 +918,8 @@ pub async fn process_accession_stream(
     retry_times: u32,
     keep_fastas: bool,
     download_only: bool,
-    filter: bool,
+    filter_sigs: bool,
+    no_overwrite_fasta: bool,
     send_sigs: Arc<Sender<BuildCollection>>,
     send_failed: Arc<Sender<AccessionData>>,
     send_failed_checksums: Arc<Sender<FailedChecksum>>,
@@ -970,7 +971,7 @@ pub async fn process_accession_stream(
                 }
 
                 // filter tells us whether or not we need to filter sigs
-                if filter {
+                if filter_sigs {
                     if let Some(existing_manifest) = existing_records_map.get(&accinfo.name) {
                         sigs.filter_by_manifest(existing_manifest);
                     }
@@ -982,7 +983,7 @@ pub async fn process_accession_stream(
                     if keep_fastas {
                         let download_filename = accinfo.download_filename.as_deref().unwrap_or_default();
                         let fasta_final_path = download_path.join(download_filename);
-                        fasta_final_path.exists()
+                        no_overwrite_fasta && fasta_final_path.exists()
                     } else {
                         true
                     }
@@ -1133,6 +1134,7 @@ pub async fn gbsketch(
     concurrency_limit: usize,
     api_key: String,
     verbose: bool,
+    no_overwrite_fasta: bool,
     write_urlsketch_csv: bool,
     output_sigs: Option<String>,
 ) -> Result<(), anyhow::Error> {
@@ -1292,6 +1294,7 @@ pub async fn gbsketch(
         keep_fastas,
         download_only,
         filter,
+        no_overwrite_fasta,
         receivers.send_sigs,
         receivers.send_failed,
         receivers.send_failed_checksums,
@@ -1332,6 +1335,7 @@ pub async fn urlsketch(
     concurrency_limit: usize,
     force: bool,
     verbose: bool,
+    no_overwrite_fasta: bool,
     output_sigs: Option<String>,
     failed_checksums_csv: Option<String>,
 ) -> Result<(), anyhow::Error> {
@@ -1391,6 +1395,7 @@ pub async fn urlsketch(
         keep_fastas,
         download_only,
         filter,
+        no_overwrite_fasta,
         receivers.send_sigs,
         receivers.send_failed,
         receivers.send_failed_checksums,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ fn set_tokio_thread_pool(num_threads: usize) -> PyResult<usize> {
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (input_csv, param_str, failed_csv, failed_checksums, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, api_key, verbose, write_urlsketch_csv, output_sigs=None))]
+#[pyo3(signature = (input_csv, param_str, failed_csv, failed_checksums, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, api_key, verbose, no_overwrite_fasta, write_urlsketch_csv, output_sigs=None))]
 fn do_gbsketch(
     py: Python,
     input_csv: String,
@@ -66,6 +66,7 @@ fn do_gbsketch(
     n_permits: usize,
     api_key: String,
     verbose: bool,
+    no_overwrite_fasta: bool,
     write_urlsketch_csv: bool,
     output_sigs: Option<String>,
 ) -> anyhow::Result<u8> {
@@ -85,6 +86,7 @@ fn do_gbsketch(
         n_permits,
         api_key,
         verbose,
+        no_overwrite_fasta,
         write_urlsketch_csv,
         output_sigs,
     ) {
@@ -98,7 +100,7 @@ fn do_gbsketch(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (input_csv, param_str, failed_csv, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, force, verbose, output_sigs=None, failed_checksums=None))]
+#[pyo3(signature = (input_csv, param_str, failed_csv, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, force, verbose, no_overwrite_fasta, output_sigs=None, failed_checksums=None))]
 fn do_urlsketch(
     py: Python,
     input_csv: String,
@@ -114,6 +116,7 @@ fn do_urlsketch(
     n_permits: usize,
     force: bool,
     verbose: bool,
+    no_overwrite_fasta: bool,
     output_sigs: Option<String>,
     failed_checksums: Option<String>,
 ) -> anyhow::Result<u8> {
@@ -132,6 +135,7 @@ fn do_urlsketch(
         n_permits,
         force,
         verbose,
+        no_overwrite_fasta,
         output_sigs,
         failed_checksums,
     ) {

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -139,6 +139,11 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             action="store_true",
             help="Write urlsketch-formatted csv with all direct download links. Will be '{input_csv}.urlsketch.csv'.",
         )
+        p.add_argument(
+            "--no-overwrite-fasta",
+            action="store_true",
+            help="Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.",
+        )
         group = p.add_mutually_exclusive_group()
         group.add_argument(
             "-g",
@@ -162,6 +167,9 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
         if args.download_only and not args.keep_fasta:
             notify("Error: '--download-only' requires '--keep-fasta'.")
             sys.exit(-1)
+        if args.no_overwrite_fasta and not args.keep_fasta:
+            notify("Error: '--no-overwrite-fasta' requires '--keep-fasta'.")
+            sys.exit(-1)
         if args.output is None and not args.download_only:
             notify(
                 "Error: output signature zipfile is required if not using '--download-only'."
@@ -173,6 +181,9 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
                 args.api_key = api_key
             else:
                 args.api_key = ""
+        if args.batch_size > 0:
+            args.no_overwrite_fasta = True
+            notify("Batch size is set, enabling --no-overwrite-fasta by default.")
         # convert to a single string for easier rust handling
         args.param_string = "_".join(args.param_string)
         # lowercase the param string
@@ -212,6 +223,7 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             args.n_simultaneous_downloads,
             args.api_key,
             args.verbose,
+            args.no_overwrite_fasta,
             args.write_urlsketch_csv,
             args.output,
         )
@@ -322,6 +334,11 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             action="store_true",
             help="print progress for every download.",
         )
+        p.add_argument(
+            "--no-overwrite-fasta",
+            action="store_true",
+            help="Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.",
+        )
         group = p.add_mutually_exclusive_group()
         group.add_argument(
             "-g",
@@ -345,11 +362,18 @@ class Download_and_Sketch_Url(CommandLinePlugin):
         if args.download_only and not args.keep_fasta:
             notify("Error: '--download-only' requires '--keep-fasta'.")
             sys.exit(-1)
+        if args.no_overwrite_fasta and not args.keep_fasta:
+            notify("Error: '--no-overwrite-fasta' requires '--keep-fasta'.")
+            sys.exit(-1)
         if args.output is None and not args.download_only:
             notify(
                 "Error: output signature zipfile is required if not using '--download-only'."
             )
             sys.exit(-1)
+
+        if args.batch_size > 0:
+            args.no_overwrite_fasta = True
+            notify("Batch size is set, enabling --no-overwrite-fasta by default.")
 
         # convert to a single string for easier rust handling
         args.param_string = "_".join(args.param_string)
@@ -380,6 +404,7 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             args.n_simultaneous_downloads,
             args.force,
             args.verbose,
+            args.no_overwrite_fasta,
             args.output,
             args.checksum_fail,
         )

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -324,6 +324,35 @@ def test_gbsketch_save_fastas(runtmp):
                 assert sig.md5sum() == ss3.md5sum()
 
 
+def test_gbsketch_save_fastas_proteomes_only(runtmp, capfd):
+    acc_csv = get_test_data('acc.csv')
+    failed = runtmp.output('failed.csv')
+    out_dir = runtmp.output('out_fastas')
+
+    runtmp.sourmash('scripts', 'gbsketch', acc_csv, '--download-only', '--proteomes-only',
+                    '--failed', failed, '-r', '4', '--fastas', out_dir, '--keep-fasta')
+
+    fa_files = os.listdir(out_dir)
+    captured = capfd.readouterr()
+    print(captured.err)
+    assert set(fa_files) == set(['GCA_000961135.2_protein.faa.gz'])
+    assert "Skipped 1 download(s) due to missing download URLs" in captured.err 
+
+
+def test_gbsketch_save_fastas_genomes_only(runtmp, capfd):
+    acc_csv = get_test_data('acc.csv')
+    failed = runtmp.output('failed.csv')
+    out_dir = runtmp.output('out_fastas')
+
+    runtmp.sourmash('scripts', 'gbsketch', acc_csv, '--download-only', '--genomes-only',
+                    '--failed', failed, '-r', '4', '--fastas', out_dir, '--keep-fasta')
+
+    fa_files = os.listdir(out_dir)
+    captured = capfd.readouterr()
+    print(captured.err)
+    assert set(fa_files) == set(['GCA_000175535.1_genomic.fna.gz', 'GCA_000961135.2_genomic.fna.gz'])
+
+
 def test_gbsketch_save_fastas_no_overwrite(runtmp, capfd):
     acc_csv = get_test_data('acc.csv')
     failed = runtmp.output('failed.csv')
@@ -1361,7 +1390,7 @@ def test_gbsketch_from_gbsketch_failed(runtmp, capfd):
     ch_fail = runtmp.output('checksum_dl_failed.csv')
 
     runtmp.sourmash('scripts', 'gbsketch', acc_csv, '-o', output,
-                    '--failed', failed, '-r', '1', '--checksum-fail', ch_fail,
+                    '--failed', failed, '-r', '4', '--checksum-fail', ch_fail,
                     '--param-str', "dna,k=31,scaled=1000", '-p', "protein,k=10,scaled=200")
 
     assert os.path.exists(failed)
@@ -1384,7 +1413,7 @@ def test_gbsketch_from_gbsketch_failed(runtmp, capfd):
     # since the protein file doesn't exist at NCBI, we won't be able to find any links in the downloaded dehydrated zip.
     with pytest.raises(utils.SourmashCommandFailed):
         runtmp.sourmash('scripts', 'gbsketch', failed, '-o', out2,
-                    '--failed', fail2, '-r', '1',
+                    '--failed', fail2, '-r', '4',
                     '-p', "protein,k=10,scaled=200")
     captured = capfd.readouterr()
     print(captured.out)

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -903,6 +903,58 @@ def test_gbsketch_simple_batch_restart(runtmp, capfd):
     assert all_siginfo == expected_siginfo
 
 
+def test_gbsketch_simple_batch_restart_nobatch(runtmp, capfd):
+    acc_csv = get_test_data('acc.csv')
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+    ch_fail = runtmp.output('checksum_dl_failed.csv')
+
+    out1 = runtmp.output('simple.1.zip')
+    out2 = runtmp.output('simple.2.zip')
+    out3 = runtmp.output('simple.3.zip')
+
+    sig2 = get_test_data('GCA_000961135.2.sig.gz')
+
+    # first, cat sig2 into an output file that will trick gbsketch into thinking it's a prior batch
+    runtmp.sourmash('sig', 'cat', sig2, '-o', out1)
+    assert os.path.exists(out1)
+
+    runtmp.sourmash('scripts', 'gbsketch', acc_csv, '-o', output,
+                    '--failed', failed, '-r', '3', '--checksum-fail', ch_fail,
+                    '--param-str', "dna,k=31,scaled=1000,abund", '-p', "protein,k=10,scaled=200",
+                    '--batch-size', '1')
+
+    assert os.path.exists(out1)
+    assert os.path.exists(out2)
+    assert os.path.exists(out3)
+    assert not os.path.exists(output) # for now, orig output file should be empty.
+    captured = capfd.readouterr()
+    print(captured.err)
+    siglist = []
+    for out_file in [out1, out2, out3]:
+        idx = sourmash.load_file_as_index(out_file)
+        sigs = list(idx.signatures())
+        siglist.extend(sigs)
+    assert len(siglist) == 4  # k=21 and k=31 from sig2, k=31 from sig1, and k=10 from sig3
+
+    assert "Skipped 1 download(s) due to missing download URLs." in captured.err
+    assert "Skipped 1 download(s) due to existing sketches and/or FASTA files." in captured.err
+
+    # run again, but without batching
+    runtmp.sourmash('scripts', 'gbsketch', acc_csv, '-o', output,
+                    '--failed', failed, '-r', '3', '--checksum-fail', ch_fail,
+                    '--param-str', "dna,k=31,scaled=1000,abund", '-p', "protein,k=10,scaled=200")
+    captured = capfd.readouterr()
+    print(captured.err)
+
+    assert "Skipped 1 download(s) due to missing download URLs." in captured.err
+    assert "Skipped 1 download(s) due to existing sketches and/or FASTA files." not in captured.err
+    assert os.path.exists(output)
+    idx = sourmash.load_file_as_index(output)
+    sigs = list(idx.signatures())
+    assert len(sigs) == 3  # should include all 3 possible signatures, including the one from out1
+
+
 def test_gbsketch_simple_batch_restart_sig_zip(runtmp, capfd):
     acc_csv = get_test_data('acc.csv')
     output = runtmp.output('simple.sig.zip')

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -324,6 +324,43 @@ def test_gbsketch_save_fastas(runtmp):
                 assert sig.md5sum() == ss3.md5sum()
 
 
+def test_gbsketch_save_fastas_no_overwrite(runtmp, capfd):
+    acc_csv = get_test_data('acc.csv')
+    failed = runtmp.output('failed.csv')
+    out_dir = runtmp.output('out_fastas')
+    ch_fail = runtmp.output('checksum_dl_failed.csv')
+
+    fa1 = runtmp.output('out_fastas/GCA_000961135.2_genomic.fna.gz')
+
+    # first run to get one file downloaded 
+    single_acc_csv = runtmp.output('single_acc.csv')
+    with open(acc_csv, 'r') as inF, open(single_acc_csv, 'w') as outF:
+        lines = inF.readlines()
+        # only take the first acc for this test
+        outF.write(lines[0])  # Header
+        outF.write(lines[1])
+    
+    # Run the first gbsketch to download the fasta files
+    runtmp.sourmash('scripts', 'gbsketch', single_acc_csv, '--download-only',
+                    '--failed', failed, '-r', '3', '--fastas', out_dir, '--keep-fasta',
+                    '--checksum-fail', ch_fail, '-g')
+    assert os.path.exists(fa1)
+    fa_files = os.listdir(out_dir)
+    assert set(fa_files) == set(['GCA_000961135.2_genomic.fna.gz'])
+
+    runtmp.sourmash('scripts', 'gbsketch', acc_csv, '--download-only',
+                    '--failed', failed, '-r', '3', '--fastas', out_dir, '--keep-fasta',
+                    '--checksum-fail', ch_fail, '-g', '--no-overwrite-fasta')
+
+    assert not runtmp.last_result.out # stdout should be empty
+    captured = capfd.readouterr()
+    print(captured.err)
+    assert "Skipped 1 download(s) due to existing sketches and/or FASTA files." in captured.err
+
+    fa_files = os.listdir(out_dir)
+    assert set(fa_files) == set(['GCA_000175535.1_genomic.fna.gz', 'GCA_000961135.2_genomic.fna.gz'])
+
+
 def test_gbsketch_download_only(runtmp, capfd):
     acc_csv = get_test_data('acc.csv')
     failed = runtmp.output('failed.csv')

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -902,6 +902,56 @@ def test_urlsketch_simple_batch_restart_incomplete(runtmp, capfd):
     assert all_siginfo == expected_siginfo, f"Loaded sigs: {all_siginfo}, expected: {expected_siginfo}"
 
 
+def test_urlsketch_simple_batch_restart_nobatch(runtmp, capfd):
+    acc_csv = get_test_data('acc-url.csv')
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+    ch_fail = runtmp.output('checksum_dl_failed.csv')
+
+    out1 = runtmp.output('simple.1.zip')
+    out2 = runtmp.output('simple.2.zip')
+    out3 = runtmp.output('simple.3.zip')
+
+    sig2 = get_test_data('GCA_000961135.2.sig.gz')
+
+    # first, cat sig2 into an output file that will trick gbsketch into thinking it's a prior batch
+    runtmp.sourmash('sig', 'cat', sig2, '-o', out1)
+    assert os.path.exists(out1)
+
+    runtmp.sourmash('scripts', 'urlsketch', acc_csv, '-o', output,
+                    '--failed', failed, '-r', '3', '--checksum-fail', ch_fail,
+                    '--param-str', "dna,k=31,scaled=1000,abund", '-p', "protein,k=10,scaled=200",
+                    '--batch-size', '1')
+
+    assert os.path.exists(out1)
+    assert os.path.exists(out2)
+    assert os.path.exists(out3)
+    assert not os.path.exists(output) # for now, orig output file should be empty.
+    captured = capfd.readouterr()
+    print(captured.err)
+    siglist = []
+    for out_file in [out1, out2, out3]:
+        idx = sourmash.load_file_as_index(out_file)
+        sigs = list(idx.signatures())
+        siglist.extend(sigs)
+    assert len(siglist) == 4  # k=21 and k=31 from sig2, k=31 from sig1, and k=10 from sig3
+
+    assert "Skipped 1 download(s) due to existing sketches and/or FASTA files." in captured.err
+
+    # run again, but without batching
+    runtmp.sourmash('scripts', 'urlsketch', acc_csv, '-o', output,
+                    '--failed', failed, '-r', '3', '--checksum-fail', ch_fail,
+                    '--param-str', "dna,k=31,scaled=1000,abund", '-p', "protein,k=10,scaled=200")
+    captured = capfd.readouterr()
+    print(captured.err)
+
+    assert "Skipped 1 download(s) due to existing sketches and/or FASTA files." not in captured.err
+    assert os.path.exists(output)
+    idx = sourmash.load_file_as_index(output)
+    sigs = list(idx.signatures())
+    assert len(sigs) == 3   # k=31 from sig1 and sig2, k=10 from sig3
+
+
 def test_urlsketch_simple_batch_restart_skipcount(runtmp, capfd):
     acc_csv = get_test_data('acc-url.csv')
     output = runtmp.output('simple.zip')


### PR DESCRIPTION
- Restores proper moltype FASTA filtering via `--genomes-only` and `--proteomes-only` for `--keep-fasta`. We must have lost this in the recent refactor. Adds tests for these cases.
- Improves batched restart for `--keep-fasta` by avoiding redownloading and overwriting fastas. This works because we now mark incomplete fasta files with `.incomplete` and only rename when finished (so we can ~trust that properly-named fasta files are complete).
  - Adds `--no-overwrite-fasta` to allow avoiding overwriting even if not batching (automatically turned on with batching).
- Adds reporting re: # skipped due to moltype exclusion, existing sigs and/or fasta, and (for gbsketch only, missing URLs).
- Make sure we don't read existing sig batches if not using batching (`--batch-size`)
- update docs to reflect recent changes

