### PR TITLE
MRG: update help for simultaneous downloads; clean up prior `n` limitation code

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ options:
   -r RETRY_TIMES, --retry-times RETRY_TIMES
                         Number of times to retry failed downloads (default=3).
   -n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30}, --n-simultaneous-downloads {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30}
-                        Number of files to download simultaneously (1-30; default=10). Note that simultaneous downloads are held in memory during download. Please limit downloads accordingly for large genomes.
+                        Number of files to download simultaneously (1-30; default=10).
   -a API_KEY, --api-key API_KEY
                         API Key for NCBI REST API. Alternatively, set NCBI_API_KEY environmental variable. If provided, will be used when downloading the initial dehyrated file.
   -v, --verbose         print progress for every download.
@@ -207,8 +207,7 @@ options:
   -r RETRY_TIMES, --retry-times RETRY_TIMES
                         Number of times to retry failed downloads (default=3).
   -n {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30}, --n-simultaneous-downloads {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30}
-                        Number of files to download simultaneously (1-30; default=10). Restrict this to match your servers limits, otherwise many downloads will fail. Note that all simultaneous downloads are held in memory during download.
-                        Please limit downloads accordingly for large genomes.
+                        Number of files to download simultaneously (1-30; default=10).
   --force               Skip input rows with empty or improper URLs. Warning: these will NOT be added to the failures file.
   -v, --verbose         print progress for every download.
   --no-overwrite-fasta  Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -120,7 +120,7 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             default=10,
             type=int,
             choices=range(1, 31),
-            help="Number of files to download simultaneously (1-30; default=10). Note that simultaneous downloads are held in memory during download. Please limit downloads accordingly for large genomes.",
+            help="Number of files to download simultaneously (1-30; default=10).",
         )
         p.add_argument(
             "-a",
@@ -195,13 +195,6 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             args.failed = os.path.basename(args.input_csv) + '.fail.csv'
         if args.checksum_fail is None:
             args.checksum_fail = os.path.basename(args.input_csv) + '.checksum_fail.csv'
-
-        if args.n_simultaneous_downloads is None:
-            if args.api_key:
-                notify("API key provided - setting --n-simultaneous-downloads to 9")
-                args.n_simultaneous_downloads = 9
-            else:
-                args.n_simultaneous_downloads = 3
 
         notify(
             f"Downloading and sketching all accessions in '{args.input_csv} using {args.n_simultaneous_downloads} simultaneous downloads, {args.retry_times} retries, and {num_threads} threads."
@@ -321,7 +314,7 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             default=10,
             type=int,
             choices=range(1, 31),
-            help="Number of files to download simultaneously (1-30; default=10).  Restrict this to match your servers limits, otherwise many downloads will fail. Note that all simultaneous downloads are held in memory during download. Please limit downloads accordingly for large genomes.",
+            help="Number of files to download simultaneously (1-30; default=10).",
         )
         p.add_argument(
             "--force",


### PR DESCRIPTION
- Since we now set a default for `--n-simultaneous-downloads`, it should never be `None` and the limitation code based on NCBI API Key should never trigger. But let's clean it up - it's no longer needed.
- The help for `--n-simultaneous-downloads` includes outdated guidance on memory limitation. Remove.