### PR TITLE
MRG: add explicit sigterm handling

### DIFF
--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -1437,6 +1437,8 @@ pub async fn urlsketch(
         batch_size,
         batch_index,
     );
+    // setup handler to catch both ctrl-c and sigterm
+    setup_signal_handlers(cancel_token.clone());
 
     let client = Arc::new(Client::new());
 

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -5,6 +5,9 @@ import os
 import pytest
 import gzip
 import screed
+import signal
+import subprocess
+import time
 
 import csv
 import sourmash
@@ -1852,3 +1855,53 @@ def test_urlsketch_verbose(runtmp, capfd):
     assert "Starting download 1/3 (33%) - accession: 'GCA_000961135.2', moltype: DNA" in captured.out
     assert "Starting download 2/3 (67%) - accession: 'GCA_000961135.2', moltype: protein" in captured.out
     assert "Starting download 3/3 (100%) - accession: 'GCA_000175535.1', moltype: DNA" in captured.out
+
+
+def test_urlsketch_sigterm_handling(runtmp):
+    acc_csv = get_test_data('acc-url.csv')
+    output = runtmp.output('simple.zip')
+    failed = runtmp.output('failed.csv')
+    ch_fail = runtmp.output('checksum_dl_failed.csv')
+
+    # Start the process using subprocess so we can send SIGTERM
+    proc = subprocess.Popen(
+        [
+            "python", "-m", "sourmash", "scripts", "urlsketch", acc_csv,
+            "-o", output,
+            "--failed", failed,
+            "-r", "3",
+            "--checksum-fail", ch_fail,
+            "--param-str", "dna,k=31,scaled=1000",
+            "-p", "protein,k=10,scaled=200",
+        ],
+        cwd=runtmp.location,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        preexec_fn=os.setsid,  # important: send SIGTERM to full process group
+    )
+
+    time.sleep(1)  # allow urlsketch to start up
+
+    # Send SIGTERM
+    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+
+    try:
+        stdout, stderr = proc.communicate(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        assert False, "urlsketch did not exit after SIGTERM"
+
+    stderr_str = stderr.decode()
+    stdout_str = stdout.decode()
+
+    # Optional: print for debugging
+    print("STDOUT:", stdout_str)
+    print("STDERR:", stderr_str)
+
+    # SIGTERM would normally end the process with code 143 (128 + SIGTERM)
+    # BUT, I've set it up so we do some graceful shutdown and then `bail`, meaning we should get exit code 1
+    assert proc.returncode in (1, 143), f"Unexpected return code: {proc.returncode}"
+
+    # Optionally check for graceful message
+    assert "SIGTERM" in stderr_str
+    assert "Shutting down early" in stderr_str


### PR DESCRIPTION
Adds explicit checks for `SIGTERM`, as would be sent via slurm/snakemake+slurm. Adds tests for catching sigterm.

When we get a shutdown request (ctrl-C or sigterm), we don't shut down immediately. Instead, we cancel each process as they get to a stop check (these are frequent, e.g. each chunk during file download) so we don't leave any spawned processes running. After that, we will exit out to the main loop and enter into the `cancel_token.is_cancelled()` at the end, meaning we exit via `bail` (exit code 1).

- fixes #242