### PR TITLE
MRG: fix duplicated failure writing for missing gbsketch URLs

### DIFF
--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -1290,11 +1290,11 @@ pub async fn gbsketch(
                 None => download_failures.push(accinfo.clone()),
             }
         }
+    }
 
-        // if we failed to get a download link, write to download failures
-        for fail in &download_failures {
-            let _ = receivers.send_failed.send(fail.clone()).await;
-        }
+    // if we failed to get a download link, write to download failures
+    for fail in &download_failures {
+        let _ = receivers.send_failed.send(fail.clone()).await;
     }
 
     // retain only accessions without empty URLs (can't download)


### PR DESCRIPTION
Previously, we were writing the download failures for missing `gbsketch` URLs (fetch links we could not find in the dehydrated zipfile) inside of the `for accinfo` loop, meaning we wrote each multiple times. This PR moves the writing code outside of the loop to avoid duplicated failure writing.

- fixes #240 