### PR TITLE
MRG: optionally allow empty sig zips; write list of batch outputs to file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "sourmash_plugin_directsketch"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async_zip",

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ options:
   --write-urlsketch-csv
                         Write urlsketch-formatted csv with all direct download links. Will be '{input_csv}.urlsketch.csv'.
   --no-overwrite-fasta  Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.
-  --allow-empty-sigs    Allow empty signatures to be written to the output zipfile. Useful if restarting from batching and there are no more signatures that can be built.
+  --no-fail-on-empty    Do not fail if no signatures can be written (output zipfile will not be created). Useful if restarting from batching and there are no more signatures that
+                        can be built.
   -g, --genomes-only    Download and sketch genome (DNA) files only.
   -m, --proteomes-only  Download and sketch proteome (protein) files only.
 ```
@@ -210,7 +211,8 @@ options:
   --force               Skip input rows with empty or improper URLs. Warning: these will NOT be added to the failures file.
   -v, --verbose         print progress for every download.
   --no-overwrite-fasta  Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.
-  --allow-empty-sigs    Allow empty signatures to be written to the output zipfile. Useful if restarting from batching and there are no more signatures that can be built.
+  --no-fail-on-empty    Do not fail if no signatures can be written (output zipfile will not be created). Useful if restarting from batching and there are no more signatures that
+                        can be built.
   -g, --genomes-only    Download and sketch genome (DNA) files only.
   -m, --proteomes-only  Download and sketch proteome (protein) files only.
 ```

--- a/README.md
+++ b/README.md
@@ -135,8 +135,7 @@ options:
   --write-urlsketch-csv
                         Write urlsketch-formatted csv with all direct download links. Will be '{input_csv}.urlsketch.csv'.
   --no-overwrite-fasta  Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.
-  --no-fail-on-empty    Do not fail if no signatures can be written (output zipfile will not be created). Useful if restarting from batching and there are no more signatures that
-                        can be built.
+  --allow-completed     If batching and no more signatures can be created/written, exit cleanly anyway. New output zipfile(s) will not be created.
   -g, --genomes-only    Download and sketch genome (DNA) files only.
   -m, --proteomes-only  Download and sketch proteome (protein) files only.
 ```
@@ -211,8 +210,7 @@ options:
   --force               Skip input rows with empty or improper URLs. Warning: these will NOT be added to the failures file.
   -v, --verbose         print progress for every download.
   --no-overwrite-fasta  Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.
-  --no-fail-on-empty    Do not fail if no signatures can be written (output zipfile will not be created). Useful if restarting from batching and there are no more signatures that
-                        can be built.
+  --allow-completed     If batching and no more signatures can be created/written, exit cleanly anyway. New output zipfile(s) will not be created.
   -g, --genomes-only    Download and sketch genome (DNA) files only.
   -m, --proteomes-only  Download and sketch proteome (protein) files only.
 ```

--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -1431,7 +1431,8 @@ pub async fn gbsketch(
     if batch_size > 0 && output_sigs.is_some() && completed_batchlist.is_some() {
         // write list of all batches
         let outpath: Utf8PathBuf = output_sigs.clone().unwrap().into();
-        let batch_list_file = outpath.with_extension("batches.txt");
+        let batch_list_file =
+            outpath.with_file_name(format!("{}.batches.txt", outpath.file_name().unwrap()));
 
         let batches = completed_batchlist.expect("Failed to get list of completed batches.");
         let guard = batches.lock().await;
@@ -1572,7 +1573,8 @@ pub async fn urlsketch(
     if batch_size > 0 && output_sigs.is_some() && completed_batchlist.is_some() {
         // write list of all batches
         let outpath: Utf8PathBuf = output_sigs.clone().unwrap().into();
-        let batch_list_file = outpath.with_extension("batches.txt");
+        let batch_list_file =
+            outpath.with_file_name(format!("{}.batches.txt", outpath.file_name().unwrap()));
 
         let batches = completed_batchlist.expect("Failed to get list of completed batches.");
         let guard = batches.lock().await;

--- a/src/directsketch.rs
+++ b/src/directsketch.rs
@@ -1239,7 +1239,7 @@ pub async fn gbsketch(
     concurrency_limit: usize,
     api_key: String,
     verbose: bool,
-    allow_empty_sigs: bool,
+    no_fail_on_empty: bool,
     no_overwrite_fasta: bool,
     write_urlsketch_csv: bool,
     output_sigs: Option<String>,
@@ -1457,7 +1457,7 @@ pub async fn gbsketch(
 
     // critical error flag tracks whether or not we've written any sigs
     // check this here at end. Bail if we wrote expected sigs but wrote none.
-    if critical_error_flag.load(Ordering::SeqCst) & !download_only & !allow_empty_sigs {
+    if critical_error_flag.load(Ordering::SeqCst) & !download_only & !no_fail_on_empty {
         bail!("No signatures written, exiting.");
     }
 
@@ -1481,7 +1481,7 @@ pub async fn urlsketch(
     concurrency_limit: usize,
     force: bool,
     verbose: bool,
-    allow_empty_sigs: bool,
+    no_fail_on_empty: bool,
     no_overwrite_fasta: bool,
     output_sigs: Option<String>,
     failed_checksums_csv: Option<String>,
@@ -1599,7 +1599,7 @@ pub async fn urlsketch(
 
     // critical error flag tracks whether or not we've written any sigs
     // check this here at end. Bail if we wrote expected sigs but wrote none.
-    if critical_error_flag.load(Ordering::SeqCst) & !download_only & !allow_empty_sigs {
+    if critical_error_flag.load(Ordering::SeqCst) & !download_only & !no_fail_on_empty {
         bail!("No signatures written, exiting.");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ fn set_tokio_thread_pool(num_threads: usize) -> PyResult<usize> {
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (input_csv, param_str, failed_csv, failed_checksums, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, api_key, verbose, no_overwrite_fasta, write_urlsketch_csv, output_sigs=None))]
+#[pyo3(signature = (input_csv, param_str, failed_csv, failed_checksums, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, api_key, verbose, allow_empty_sigs, no_overwrite_fasta, write_urlsketch_csv, output_sigs=None))]
 fn do_gbsketch(
     py: Python,
     input_csv: String,
@@ -66,6 +66,7 @@ fn do_gbsketch(
     n_permits: usize,
     api_key: String,
     verbose: bool,
+    allow_empty_sigs: bool,
     no_overwrite_fasta: bool,
     write_urlsketch_csv: bool,
     output_sigs: Option<String>,
@@ -86,6 +87,7 @@ fn do_gbsketch(
         n_permits,
         api_key,
         verbose,
+        allow_empty_sigs,
         no_overwrite_fasta,
         write_urlsketch_csv,
         output_sigs,
@@ -100,7 +102,7 @@ fn do_gbsketch(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (input_csv, param_str, failed_csv, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, force, verbose, no_overwrite_fasta, output_sigs=None, failed_checksums=None))]
+#[pyo3(signature = (input_csv, param_str, failed_csv, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, force, verbose, allow_empty_sigs, no_overwrite_fasta, output_sigs=None, failed_checksums=None))]
 fn do_urlsketch(
     py: Python,
     input_csv: String,
@@ -116,6 +118,7 @@ fn do_urlsketch(
     n_permits: usize,
     force: bool,
     verbose: bool,
+    allow_empty_sigs: bool,
     no_overwrite_fasta: bool,
     output_sigs: Option<String>,
     failed_checksums: Option<String>,
@@ -135,6 +138,7 @@ fn do_urlsketch(
         n_permits,
         force,
         verbose,
+        allow_empty_sigs,
         no_overwrite_fasta,
         output_sigs,
         failed_checksums,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ fn set_tokio_thread_pool(num_threads: usize) -> PyResult<usize> {
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (input_csv, param_str, failed_csv, failed_checksums, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, api_key, verbose, allow_empty_sigs, no_overwrite_fasta, write_urlsketch_csv, output_sigs=None))]
+#[pyo3(signature = (input_csv, param_str, failed_csv, failed_checksums, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, api_key, verbose, allow_completed, no_overwrite_fasta, write_urlsketch_csv, output_sigs=None))]
 fn do_gbsketch(
     py: Python,
     input_csv: String,
@@ -66,7 +66,7 @@ fn do_gbsketch(
     n_permits: usize,
     api_key: String,
     verbose: bool,
-    allow_empty_sigs: bool,
+    allow_completed: bool,
     no_overwrite_fasta: bool,
     write_urlsketch_csv: bool,
     output_sigs: Option<String>,
@@ -87,7 +87,7 @@ fn do_gbsketch(
         n_permits,
         api_key,
         verbose,
-        allow_empty_sigs,
+        allow_completed,
         no_overwrite_fasta,
         write_urlsketch_csv,
         output_sigs,
@@ -102,7 +102,7 @@ fn do_gbsketch(
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (input_csv, param_str, failed_csv, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, force, verbose, allow_empty_sigs, no_overwrite_fasta, output_sigs=None, failed_checksums=None))]
+#[pyo3(signature = (input_csv, param_str, failed_csv, retry_times, fasta_location, keep_fastas, genomes_only, proteomes_only, download_only, batch_size, n_permits, force, verbose, allow_completed, no_overwrite_fasta, output_sigs=None, failed_checksums=None))]
 fn do_urlsketch(
     py: Python,
     input_csv: String,
@@ -118,7 +118,7 @@ fn do_urlsketch(
     n_permits: usize,
     force: bool,
     verbose: bool,
-    allow_empty_sigs: bool,
+    allow_completed: bool,
     no_overwrite_fasta: bool,
     output_sigs: Option<String>,
     failed_checksums: Option<String>,
@@ -138,7 +138,7 @@ fn do_urlsketch(
         n_permits,
         force,
         verbose,
-        allow_empty_sigs,
+        allow_completed,
         no_overwrite_fasta,
         output_sigs,
         failed_checksums,

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -144,6 +144,11 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             action="store_true",
             help="Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.",
         )
+        p.add_argument(
+            "--allow-empty-sigs",
+            action="store_true",
+            help="Allow empty signatures to be written to the output zipfile. Useful if restarting from batching and there are no more signatures that can be built.",
+        )
         group = p.add_mutually_exclusive_group()
         group.add_argument(
             "-g",
@@ -216,6 +221,7 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             args.n_simultaneous_downloads,
             args.api_key,
             args.verbose,
+            args.allow_empty_sigs,
             args.no_overwrite_fasta,
             args.write_urlsketch_csv,
             args.output,
@@ -332,6 +338,11 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             action="store_true",
             help="Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.",
         )
+        p.add_argument(
+            "--allow-empty-sigs",
+            action="store_true",
+            help="Allow empty signatures to be written to the output zipfile. Useful if restarting from batching and there are no more signatures that can be built.",
+        )
         group = p.add_mutually_exclusive_group()
         group.add_argument(
             "-g",
@@ -397,6 +408,7 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             args.n_simultaneous_downloads,
             args.force,
             args.verbose,
+            args.allow_empty_sigs,
             args.no_overwrite_fasta,
             args.output,
             args.checksum_fail,

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -145,9 +145,9 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             help="Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.",
         )
         p.add_argument(
-            "--no-fail-on-empty",
+            "--allow-completed",
             action="store_true",
-            help="Do not fail if no signatures can be written (output zipfile will not be created). Useful if restarting from batching and there are no more signatures that can be built.",
+            help="If batching and no more signatures can be created/written, exit cleanly anyway. New output zipfile(s) will not be created.",
         )
         group = p.add_mutually_exclusive_group()
         group.add_argument(
@@ -189,6 +189,11 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
         if args.batch_size > 0:
             args.no_overwrite_fasta = True
             notify("Batch size is set, enabling --no-overwrite-fasta by default.")
+        else:
+            if args.allow_completed:
+                notify(
+                    "Warning: --allow-completed is set but batch size is not set (not using batching). This will not have any effect."
+                )
         # convert to a single string for easier rust handling
         args.param_string = "_".join(args.param_string)
         # lowercase the param string
@@ -221,7 +226,7 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             args.n_simultaneous_downloads,
             args.api_key,
             args.verbose,
-            args.no_fail_on_empty,
+            args.allow_completed,
             args.no_overwrite_fasta,
             args.write_urlsketch_csv,
             args.output,
@@ -339,9 +344,9 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             help="Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.",
         )
         p.add_argument(
-            "--no-fail-on-empty",
+            "--allow-completed",
             action="store_true",
-            help="Do not fail if no signatures can be written (output zipfile will not be created). Useful if restarting from batching and there are no more signatures that can be built.",
+            help="If batching and no more signatures can be created/written, exit cleanly anyway. New output zipfile(s) will not be created.",
         )
         group = p.add_mutually_exclusive_group()
         group.add_argument(
@@ -378,7 +383,10 @@ class Download_and_Sketch_Url(CommandLinePlugin):
         if args.batch_size > 0:
             args.no_overwrite_fasta = True
             notify("Batch size is set, enabling --no-overwrite-fasta by default.")
-
+        if args.allow_completed:
+                notify(
+                    "Warning: --allow-completed is set but batch size is not set (not using batching). This will not have any effect."
+                )
         # convert to a single string for easier rust handling
         args.param_string = "_".join(args.param_string)
         # lowercase the param string
@@ -408,7 +416,7 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             args.n_simultaneous_downloads,
             args.force,
             args.verbose,
-            args.no_fail_on_empty,
+            args.allow_completed,
             args.no_overwrite_fasta,
             args.output,
             args.checksum_fail,

--- a/src/python/sourmash_plugin_directsketch/__init__.py
+++ b/src/python/sourmash_plugin_directsketch/__init__.py
@@ -145,9 +145,9 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             help="Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.",
         )
         p.add_argument(
-            "--allow-empty-sigs",
+            "--no-fail-on-empty",
             action="store_true",
-            help="Allow empty signatures to be written to the output zipfile. Useful if restarting from batching and there are no more signatures that can be built.",
+            help="Do not fail if no signatures can be written (output zipfile will not be created). Useful if restarting from batching and there are no more signatures that can be built.",
         )
         group = p.add_mutually_exclusive_group()
         group.add_argument(
@@ -221,7 +221,7 @@ class Download_and_Sketch_Assemblies(CommandLinePlugin):
             args.n_simultaneous_downloads,
             args.api_key,
             args.verbose,
-            args.allow_empty_sigs,
+            args.no_fail_on_empty,
             args.no_overwrite_fasta,
             args.write_urlsketch_csv,
             args.output,
@@ -339,9 +339,9 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             help="Requires `--keep-fasta`. If set, do not overwrite existing FASTA files in the --fastas directory. Will still re-download those files if needed for sketching.",
         )
         p.add_argument(
-            "--allow-empty-sigs",
+            "--no-fail-on-empty",
             action="store_true",
-            help="Allow empty signatures to be written to the output zipfile. Useful if restarting from batching and there are no more signatures that can be built.",
+            help="Do not fail if no signatures can be written (output zipfile will not be created). Useful if restarting from batching and there are no more signatures that can be built.",
         )
         group = p.add_mutually_exclusive_group()
         group.add_argument(
@@ -408,7 +408,7 @@ class Download_and_Sketch_Url(CommandLinePlugin):
             args.n_simultaneous_downloads,
             args.force,
             args.verbose,
-            args.allow_empty_sigs,
+            args.no_fail_on_empty,
             args.no_overwrite_fasta,
             args.output,
             args.checksum_fail,

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -824,10 +824,10 @@ def test_gbsketch_simple_batched_multiple(runtmp, capfd):
     batch_base = output.split('.zip')[0]
     print(batch_base)
     assert f"Sigs in '{batch_base}.1.zip', etc" in runtmp.last_result.err
-    assert f"Wrote list of all batches to '{batch_base}.batches.txt'" in captured.err
+    assert f"Wrote list of all batches to '{output}.batches.txt'" in captured.err
 
     # check all batch files are in the batches.txt file
-    with open(f"{batch_base}.batches.txt", 'r') as batch_file:
+    with open(f"{output}.batches.txt", 'r') as batch_file:
         batch_lines = batch_file.readlines()
         print(batch_lines)
         assert len(batch_lines) == 2

--- a/tests/test_gbsketch.py
+++ b/tests/test_gbsketch.py
@@ -1259,7 +1259,7 @@ def test_gbsketch_simple_batch_restart_nosigstowrite(runtmp, capfd):
     runtmp.sourmash('scripts', 'gbsketch', acc_csv, '-o', output,
                     '--failed', failed, '-r', '3', '--checksum-fail', ch_fail,
                     '--param-str', "dna,k=31,scaled=1000,abund", '-g',
-                    '--batch-size', '1', '--allow-empty-sigs')
+                    '--batch-size', '1', '--no-fail-on-empty')
 
     assert os.path.exists(out1)
     assert not os.path.exists(output) # for now, orig output file should be empty.

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -470,7 +470,7 @@ def test_urlsketch_bad_acc_fail_allow(runtmp, capfd):
     failed = runtmp.output('failed.csv')
 
     runtmp.sourmash('scripts', 'urlsketch', acc_mod, '-o', output,
-                    '--failed', failed, '-r', '4', '--allow-empty-sigs',
+                    '--failed', failed, '-r', '4', '--no-fail-on-empty',
                     '--param-str', "dna,k=31,scaled=1000")
 
     captured = capfd.readouterr()

--- a/tests/test_urlsketch.py
+++ b/tests/test_urlsketch.py
@@ -796,10 +796,10 @@ def test_urlsketch_simple_batched(runtmp, capfd):
     batch_base = output.split('.zip')[0]
     print(batch_base)
     assert f"Sigs in '{batch_base}.1.zip', etc" in runtmp.last_result.err
-    assert f"Wrote list of all batches to '{batch_base}.batches.txt'" in captured.err
+    assert f"Wrote list of all batches to '{output}.batches.txt'" in captured.err
 
     # check all batch files are in the batches.txt file
-    with open(f"{batch_base}.batches.txt", 'r') as batch_file:
+    with open(f"{output}.batches.txt", 'r') as batch_file:
         batch_lines = batch_file.readlines()
         print(batch_lines)
         assert len(batch_lines) == 3


### PR DESCRIPTION
This PR fixes the two issues described in #248.

- First, we add a new option, `--allow-completed`. This will allow snakemake to think that abatched workflow succeeded, even if no new signatures were written **as long as we find some existing signatures in the batches**. This will likely be most useful when restarting batches, as if there are only _failing_ entries left, there will be no signatures to write. Note that you will then want to go back and look at the failures csv file to make sure those are truly failures (and if not, to retry building those separately).
 
- Second, we add a new output for batching, the batchlist file. This file will be "{output}.batchlist.txt", so if you're writing sigs to `simple.zip`, this will be `simple.zip.batchlist.txt`. This will contain all batches detected, whether they were previously written or added during the current run. This file can be the output given to the directsketch snakemake rule, since it will be created for all batched runs. It should then be able to be used with `sourmash sig cat` or `sourmash sig collect` to combine the zipfiles into a single zip or collect them into a standalone manifest.

- fixes #248 